### PR TITLE
Set User-Agent on outbound HTTP requests

### DIFF
--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -84,7 +84,7 @@ var apiCmd = &cobra.Command{
 			req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := resolve.HTTPClient().Do(req)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 	forges "github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/config"
 	"github.com/git-pkgs/forge/internal/output"
+	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +34,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error {
+	resolve.SetUserAgent("forge/" + Version)
 	return rootCmd.Execute()
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -84,11 +84,12 @@ func newClient(domain string) *forges.Client {
 	}
 
 	// Register default forges first, so config-based registrations override them.
+	hc := HTTPClient()
 	defaults := map[string]forges.Forge{
-		"github.com":    ghforge.New(TokenForDomain("github.com"), nil),
-		"gitlab.com":    glforge.New("https://gitlab.com", TokenForDomain("gitlab.com"), nil),
-		"codeberg.org":  gitea.New("https://codeberg.org", TokenForDomain("codeberg.org"), nil),
-		"bitbucket.org": bitbucket.New(TokenForDomain("bitbucket.org"), nil),
+		"github.com":    ghforge.New(TokenForDomain("github.com"), hc),
+		"gitlab.com":    glforge.New("https://gitlab.com", TokenForDomain("gitlab.com"), hc),
+		"codeberg.org":  gitea.New("https://codeberg.org", TokenForDomain("codeberg.org"), hc),
+		"bitbucket.org": bitbucket.New(TokenForDomain("bitbucket.org"), hc),
 	}
 	for d, f := range defaults {
 		opts = append(opts, forges.WithForge(d, f))
@@ -99,9 +100,9 @@ func newClient(domain string) *forges.Client {
 	if ft := configForgeType(domain); ft != "" {
 		switch ft {
 		case "gitea", "forgejo":
-			opts = append(opts, forges.WithForge(domain, gitea.New("https://"+domain, token, nil)))
+			opts = append(opts, forges.WithForge(domain, gitea.New("https://"+domain, token, hc)))
 		case "gitlab":
-			opts = append(opts, forges.WithForge(domain, glforge.New("https://"+domain, token, nil)))
+			opts = append(opts, forges.WithForge(domain, glforge.New("https://"+domain, token, hc)))
 		}
 	}
 

--- a/internal/resolve/transport.go
+++ b/internal/resolve/transport.go
@@ -1,0 +1,31 @@
+package resolve
+
+import "net/http"
+
+var userAgent = "forge/dev"
+
+// SetUserAgent sets the User-Agent string sent on every HTTP request made
+// through HTTPClient. The CLI calls this at startup with the build version.
+func SetUserAgent(ua string) {
+	userAgent = ua
+}
+
+// HTTPClient returns an http.Client whose transport sets the User-Agent
+// header on outbound requests. Used for all forge API traffic so requests
+// are identifiable in server logs.
+func HTTPClient() *http.Client {
+	return &http.Client{Transport: &userAgentTransport{base: http.DefaultTransport}}
+}
+
+type userAgentTransport struct {
+	base http.RoundTripper
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") != "" {
+		return t.base.RoundTrip(req)
+	}
+	r := req.Clone(req.Context())
+	r.Header.Set("User-Agent", userAgent)
+	return t.base.RoundTrip(r)
+}

--- a/internal/resolve/transport_test.go
+++ b/internal/resolve/transport_test.go
@@ -1,0 +1,94 @@
+package resolve
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPClientSetsUserAgent(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+	}))
+	defer srv.Close()
+
+	c := HTTPClient()
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if got != userAgent {
+		t.Errorf("expected User-Agent %q, got %q", userAgent, got)
+	}
+	if got == "" {
+		t.Error("User-Agent was empty")
+	}
+}
+
+func TestSetUserAgent(t *testing.T) {
+	old := userAgent
+	defer func() { userAgent = old }()
+
+	SetUserAgent("forge/1.2.3")
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+	}))
+	defer srv.Close()
+
+	c := HTTPClient()
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if got != "forge/1.2.3" {
+		t.Errorf("expected User-Agent forge/1.2.3, got %q", got)
+	}
+}
+
+func TestUserAgentTransportPreservesExisting(t *testing.T) {
+	// If a caller has already set User-Agent (e.g. forge api -H "User-Agent: x"),
+	// the transport must not stomp on it.
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+	}))
+	defer srv.Close()
+
+	c := HTTPClient()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("User-Agent", "custom/1.0")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if got != "custom/1.0" {
+		t.Errorf("expected explicit User-Agent to be preserved, got %q", got)
+	}
+}
+
+func TestUserAgentTransportDoesNotMutateRequest(t *testing.T) {
+	// RoundTrippers must not modify the original request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	c := HTTPClient()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if req.Header.Get("User-Agent") != "" {
+		t.Errorf("transport mutated the original request: User-Agent=%q", req.Header.Get("User-Agent"))
+	}
+}


### PR DESCRIPTION
Closes #31.

Requests now identify themselves as `forge/<version>` instead of `Go-http-client/2.0`. The version comes from the same ldflags-injected `cli.Version` that `forge version` prints, so release builds get `forge/0.4.0` and dev builds get `forge/dev`.

The header is set by a `RoundTripper` in `internal/resolve` that wraps `http.DefaultTransport`. It clones the request before mutating headers and leaves any explicitly-set User-Agent alone, so `forge api -H "User-Agent: something"` still works as an override. The transport is wired into all four forge SDK clients via `resolve.newClient` and into the raw `forge api` path which previously used `http.DefaultClient` directly.