### PR TITLE
Skip Gitea SDK version probe to avoid nil client on unreachable hosts

### DIFF
--- a/gitea/gitea.go
+++ b/gitea/gitea.go
@@ -17,7 +17,13 @@ type giteaForge struct {
 
 // New creates a Gitea/Forgejo forge backend.
 func New(baseURL, token string, hc *http.Client) forge.Forge {
-	opts := []gitea.ClientOption{}
+	// SetGiteaVersion("") skips the SDK's /api/v1/version probe. Without
+	// it gitea.NewClient hits the network on construction and returns
+	// (nil, err) if the host is unreachable. Since this constructor is
+	// called at startup for the default codeberg.org registration whether
+	// or not the user is targeting Gitea, the probe is wasted latency at
+	// best and a stored nil client at worst.
+	opts := []gitea.ClientOption{gitea.SetGiteaVersion("")}
 	if token != "" {
 		opts = append(opts, gitea.SetToken(token))
 	}

--- a/gitea/gitea_test.go
+++ b/gitea/gitea_test.go
@@ -17,6 +17,42 @@ func giteaVersionHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintf(w, `{"version":"1.21.0"}`)
 }
 
+func TestNewWithUnreachableHostDoesNotPanic(t *testing.T) {
+	// gitea.NewClient probes /api/v1/version on construction. If that
+	// fails it returns (nil, err). We used to discard the error and store
+	// the nil client, so the first real API call would dereference nil.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // connection refused from here on
+
+	f := New(srv.URL, "", nil)
+
+	_, err := f.Repos().Get(context.Background(), "owner", "repo")
+	if err == nil {
+		t.Fatal("expected error from unreachable host")
+	}
+}
+
+func TestNewDoesNotProbeVersionEndpoint(t *testing.T) {
+	// New is called at startup for the codeberg.org default registration
+	// regardless of which forge the user is actually targeting. The version
+	// probe is wasted latency in that case.
+	var versionHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, r *http.Request) {
+		versionHits++
+		giteaVersionHandler(w, r)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_ = New(srv.URL, "", nil)
+
+	if versionHits != 0 {
+		t.Errorf("New should not probe the version endpoint, got %d hits", versionHits)
+	}
+}
+
 func TestGiteaGetRepo(t *testing.T) {
 	created := time.Date(2021, 3, 15, 10, 0, 0, 0, time.UTC)
 	updated := time.Date(2024, 5, 20, 8, 30, 0, 0, time.UTC)


### PR DESCRIPTION
Closes #58.

`gitea.NewClient` calls `/api/v1/version` during construction to check the server is at least 1.11. When that request fails (DNS error, connection refused, timeout) it returns `(nil, err)`. We were discarding the error at `gitea/gitea.go:27` and storing the nil client, so the first real API call would dereference nil and panic.

The fix passes `gitea.SetGiteaVersion("")` which sets `ignoreVersion = true` in the SDK, making the version check a no-op. `NewClient` then never hits the network and never returns nil. Connection failures now surface as ordinary errors on the first real request:

    Error: listing pull requests: Get "https://gitea.example.com/api/v1/repos/o/r/pulls?...": dial tcp: lookup gitea.example.com: no such host

This also removes a wasted round-trip on every invocation, since `New` is called at startup for the default codeberg.org registration regardless of which forge the user is actually targeting.

The first test reproduces the panic by closing an httptest server before calling into the forge. The second confirms construction no longer hits the version endpoint.