### PR TITLE
Sign release checksums with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -17,6 +18,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,18 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
Adds keyless signing of `checksums.txt` via cosign + sigstore, mirroring git-pkgs/git-pkgs@0a82984.

The version ldflags fix is already on main (added after v0.3.1 was tagged) so the next release will also fix `forge version` printing `dev`.