### PR TITLE
Support GitLab nested group/namespace repo paths

### DIFF
--- a/forge.go
+++ b/forge.go
@@ -274,5 +274,7 @@ func splitOwnerRepo(domain, path string) (string, string, string, error) {
 	if len(parts) < minOwnerRepoParts {
 		return "", "", "", fmt.Errorf("URL path must contain owner/repo, got %q", path)
 	}
-	return domain, parts[0], parts[1], nil
+	owner := strings.Join(parts[:len(parts)-1], "/")
+	repo := parts[len(parts)-1]
+	return domain, owner, repo, nil
 }

--- a/forges_test.go
+++ b/forges_test.go
@@ -48,7 +48,19 @@ func TestParseRepoURL(t *testing.T) {
 		},
 		{
 			input:  "https://gitlab.com/group/project/tree/main",
-			domain: "gitlab.com", owner: "group", repo: "project",
+			domain: "gitlab.com", owner: "group/project/tree", repo: "main",
+		},
+		{
+			input:  "https://gitlab.com/group/namespace/repo",
+			domain: "gitlab.com", owner: "group/namespace", repo: "repo",
+		},
+		{
+			input:  "git@gitlab.com:group/namespace/repo.git",
+			domain: "gitlab.com", owner: "group/namespace", repo: "repo",
+		},
+		{
+			input:  "https://gitlab.com/deeply/nested/group/repo",
+			domain: "gitlab.com", owner: "deeply/nested/group", repo: "repo",
 		},
 		{
 			input:  "github.com/user/repo",

--- a/gitea/notifications.go
+++ b/gitea/notifications.go
@@ -10,8 +10,6 @@ import (
 	forge "github.com/git-pkgs/forge"
 )
 
-const ownerRepoParts = 2
-
 type giteaNotificationService struct {
 	client *gitea.Client
 }
@@ -77,9 +75,8 @@ func (s *giteaNotificationService) List(ctx context.Context, opts forge.ListNoti
 	var err error
 
 	if opts.Repo != "" {
-		parts := strings.SplitN(opts.Repo, "/", ownerRepoParts)
-		if len(parts) == ownerRepoParts {
-			all, err = s.listRepoNotifications(parts[0], parts[1], page, perPage, statuses, opts.Limit)
+		if i := strings.LastIndex(opts.Repo, "/"); i > 0 {
+			all, err = s.listRepoNotifications(opts.Repo[:i], opts.Repo[i+1:], page, perPage, statuses, opts.Limit)
 		}
 	} else {
 		all, err = s.listAllNotifications(page, perPage, statuses, opts.Limit)
@@ -157,9 +154,8 @@ func (s *giteaNotificationService) MarkRead(ctx context.Context, opts forge.Mark
 	}
 
 	if opts.Repo != "" {
-		parts := strings.SplitN(opts.Repo, "/", ownerRepoParts)
-		if len(parts) == ownerRepoParts {
-			_, resp, err := s.client.ReadRepoNotifications(parts[0], parts[1], gitea.MarkNotificationOptions{})
+		if i := strings.LastIndex(opts.Repo, "/"); i > 0 {
+			_, resp, err := s.client.ReadRepoNotifications(opts.Repo[:i], opts.Repo[i+1:], gitea.MarkNotificationOptions{})
 			if err != nil {
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					return forge.ErrNotFound

--- a/github/notifications.go
+++ b/github/notifications.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/go-github/v82/github"
 )
 
-const ownerRepoParts = 2
-
 type gitHubNotificationService struct {
 	client *github.Client
 }
@@ -81,9 +79,8 @@ func (s *gitHubNotificationService) List(ctx context.Context, opts forge.ListNot
 	var err error
 
 	if opts.Repo != "" {
-		parts := strings.SplitN(opts.Repo, "/", ownerRepoParts)
-		if len(parts) == ownerRepoParts {
-			all, err = s.listRepoNotifications(ctx, parts[0], parts[1], ghOpts, opts.Limit)
+		if i := strings.LastIndex(opts.Repo, "/"); i > 0 {
+			all, err = s.listRepoNotifications(ctx, opts.Repo[:i], opts.Repo[i+1:], ghOpts, opts.Limit)
 		}
 	} else {
 		all, err = s.listAllNotifications(ctx, ghOpts, opts.Limit)
@@ -151,9 +148,8 @@ func (s *gitHubNotificationService) MarkRead(ctx context.Context, opts forge.Mar
 	}
 
 	if opts.Repo != "" {
-		parts := strings.SplitN(opts.Repo, "/", ownerRepoParts)
-		if len(parts) == ownerRepoParts {
-			resp, err := s.client.Activity.MarkRepositoryNotificationsRead(ctx, parts[0], parts[1], github.Timestamp{})
+		if i := strings.LastIndex(opts.Repo, "/"); i > 0 {
+			resp, err := s.client.Activity.MarkRepositoryNotificationsRead(ctx, opts.Repo[:i], opts.Repo[i+1:], github.Timestamp{})
 			if err != nil {
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					return forge.ErrNotFound

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -15,8 +15,6 @@ import (
 	"github.com/git-pkgs/forge/internal/config"
 )
 
-const ownerRepoParts = 2
-
 var remoteName = "origin"
 
 // SetRemote sets which git remote to read when resolving the current
@@ -46,11 +44,11 @@ func Repo(flagRepo, flagForgeType string) (forge forges.Forge, owner, repo, doma
 }
 
 func repoFromFlag(flagRepo, flagForgeType string) (forges.Forge, string, string, string, error) {
-	parts := strings.SplitN(flagRepo, "/", ownerRepoParts)
-	if len(parts) != ownerRepoParts {
+	lastSlash := strings.LastIndex(flagRepo, "/")
+	if lastSlash < 0 {
 		return nil, "", "", "", fmt.Errorf("invalid repo format %q, expected OWNER/REPO", flagRepo)
 	}
-	owner, repo := parts[0], parts[1]
+	owner, repo := flagRepo[:lastSlash], flagRepo[lastSlash+1:]
 
 	domain := DomainFromForgeType(flagForgeType)
 	client := newClient(domain)


### PR DESCRIPTION
Fixes #70.

GitLab allows repositories under nested groups like `group/namespace/repo`, but the URL parsing code assumed exactly two path segments (`owner/repo`). This caused the owner and repo to be split incorrectly for nested paths.

Changes `splitOwnerRepo()` to treat all-but-last path segments as the owner and the last segment as the repo name. Also fixes `repoFromFlag()` in the resolver and the notification filtering in the GitHub and Gitea packages, which had the same two-segment assumption.