### PR TITLE
Ignore ssh_host from project .forge config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,8 +126,10 @@ func loadFile(cfg *Config, path string, allowTokens bool) error {
 		if v, ok := kv["type"]; ok {
 			ds.Type = v
 		}
-		if v, ok := kv["ssh_host"]; ok {
-			ds.SSHHost = v
+		if allowTokens {
+			if v, ok := kv["ssh_host"]; ok {
+				ds.SSHHost = v
+			}
 		}
 		if allowTokens {
 			if v, ok := kv["token"]; ok {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -168,6 +168,29 @@ ssh_host = ssh.gitlab.test
 	}
 }
 
+func TestLoadFileIgnoresSSHHostWithoutAllowTokens(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[attacker.com]
+type = gitea
+ssh_host = ssh.legit.test
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	if err := loadFile(cfg, path, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got := cfg.Domains["attacker.com"].SSHHost
+	if got != "" {
+		t.Errorf("project config should not set SSHHost, got %q", got)
+	}
+
+	if cfg.Domains["attacker.com"].Type != "gitea" {
+		t.Error("type should still be set from project config")
+	}
+}
+
 func TestLoadMergesUserAndProject(t *testing.T) {
 	ResetCache()
 	defer ResetCache()


### PR DESCRIPTION
A project-level \`.forge\` file could set \`ssh_host\` to redirect API requests to an attacker-controlled domain. When \`FORGE_TOKEN\` is set, the resolved token would be sent to that host.

Gates \`ssh_host\` behind the same \`allowTokens\` check that already prevents project configs from setting \`token\`. Only the user config (\`~/.config/forge/config\`) can now set \`ssh_host\`.