### PR TITLE
Strip control characters from forge-sourced text

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -65,14 +65,14 @@ func issueViewCmd() *cobra.Command {
 				return p.PrintJSON(issue)
 			}
 
-			_, _ = fmt.Fprintf(os.Stdout, "#%d %s\n", issue.Number, issue.Title)
+			_, _ = fmt.Fprintf(os.Stdout, "#%d %s\n", issue.Number, output.Sanitize(issue.Title))
 			_, _ = fmt.Fprintf(os.Stdout, "State:   %s\n", issue.State)
-			_, _ = fmt.Fprintf(os.Stdout, "Author:  %s\n", issue.Author.Login)
+			_, _ = fmt.Fprintf(os.Stdout, "Author:  %s\n", output.Sanitize(issue.Author.Login))
 
 			if len(issue.Assignees) > 0 {
 				names := make([]string, len(issue.Assignees))
 				for i, a := range issue.Assignees {
-					names[i] = a.Login
+					names[i] = output.Sanitize(a.Login)
 				}
 				_, _ = fmt.Fprintf(os.Stdout, "Assign:  %s\n", strings.Join(names, ", "))
 			}
@@ -80,18 +80,18 @@ func issueViewCmd() *cobra.Command {
 			if len(issue.Labels) > 0 {
 				names := make([]string, len(issue.Labels))
 				for i, l := range issue.Labels {
-					names[i] = l.Name
+					names[i] = output.Sanitize(l.Name)
 				}
 				_, _ = fmt.Fprintf(os.Stdout, "Labels:  %s\n", strings.Join(names, ", "))
 			}
 
 			if issue.Milestone != nil {
-				_, _ = fmt.Fprintf(os.Stdout, "Mile:    %s\n", issue.Milestone.Title)
+				_, _ = fmt.Fprintf(os.Stdout, "Mile:    %s\n", output.Sanitize(issue.Milestone.Title))
 			}
 
 			if issue.Body != "" {
 				_, _ = fmt.Fprintln(os.Stdout)
-				_, _ = fmt.Fprintln(os.Stdout, issue.Body)
+				_, _ = fmt.Fprintln(os.Stdout, output.Sanitize(issue.Body))
 			}
 
 			if flagComments {
@@ -101,8 +101,8 @@ func issueViewCmd() *cobra.Command {
 				}
 				for _, c := range comments {
 					_, _ = fmt.Fprintln(os.Stdout)
-					_, _ = fmt.Fprintf(os.Stdout, "--- %s ---\n", c.Author.Login)
-					_, _ = fmt.Fprintln(os.Stdout, c.Body)
+					_, _ = fmt.Fprintf(os.Stdout, "--- %s ---\n", output.Sanitize(c.Author.Login))
+					_, _ = fmt.Fprintln(os.Stdout, output.Sanitize(c.Body))
 				}
 			}
 
@@ -157,7 +157,7 @@ func issueListCmd() *cobra.Command {
 			if p.Format == output.Plain {
 				lines := make([]string, len(issues))
 				for i, iss := range issues {
-					lines[i] = fmt.Sprintf("%d\t%s", iss.Number, iss.Title)
+					lines[i] = fmt.Sprintf("%d\t%s", iss.Number, output.Sanitize(iss.Title))
 				}
 				p.PrintPlain(lines)
 				return nil
@@ -168,16 +168,16 @@ func issueListCmd() *cobra.Command {
 			for i, iss := range issues {
 				labels := make([]string, len(iss.Labels))
 				for j, l := range iss.Labels {
-					labels[j] = l.Name
+					labels[j] = output.Sanitize(l.Name)
 				}
-				title := iss.Title
+				title := output.Sanitize(iss.Title)
 				if len(title) > maxTitleLength {
 					title = title[:truncatedTitleLen] + "..."
 				}
 				rows[i] = []string{
 					strconv.Itoa(iss.Number),
 					title,
-					iss.Author.Login,
+					output.Sanitize(iss.Author.Login),
 					strings.Join(labels, ", "),
 					iss.UpdatedAt.Format("2006-01-02"),
 				}

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -75,8 +75,8 @@ func prViewCmd() *cobra.Command {
 				}
 				for _, c := range comments {
 					_, _ = fmt.Fprintln(os.Stdout)
-					_, _ = fmt.Fprintf(os.Stdout, "--- %s ---\n", c.Author.Login)
-					_, _ = fmt.Fprintln(os.Stdout, c.Body)
+					_, _ = fmt.Fprintf(os.Stdout, "--- %s ---\n", output.Sanitize(c.Author.Login))
+					_, _ = fmt.Fprintln(os.Stdout, output.Sanitize(c.Body))
 				}
 			}
 
@@ -89,9 +89,9 @@ func prViewCmd() *cobra.Command {
 }
 
 func printPRDetails(pr *forges.PullRequest) {
-	_, _ = fmt.Fprintf(os.Stdout, "#%d %s\n", pr.Number, pr.Title)
+	_, _ = fmt.Fprintf(os.Stdout, "#%d %s\n", pr.Number, output.Sanitize(pr.Title))
 	_, _ = fmt.Fprintf(os.Stdout, "State:   %s\n", pr.State)
-	_, _ = fmt.Fprintf(os.Stdout, "Author:  %s\n", pr.Author.Login)
+	_, _ = fmt.Fprintf(os.Stdout, "Author:  %s\n", output.Sanitize(pr.Author.Login))
 	_, _ = fmt.Fprintf(os.Stdout, "Branch:  %s -> %s\n", pr.Head, pr.Base)
 
 	if pr.Draft {
@@ -101,7 +101,7 @@ func printPRDetails(pr *forges.PullRequest) {
 	if len(pr.Reviewers) > 0 {
 		names := make([]string, len(pr.Reviewers))
 		for i, r := range pr.Reviewers {
-			names[i] = r.Login
+			names[i] = output.Sanitize(r.Login)
 		}
 		_, _ = fmt.Fprintf(os.Stdout, "Review:  %s\n", strings.Join(names, ", "))
 	}
@@ -109,13 +109,13 @@ func printPRDetails(pr *forges.PullRequest) {
 	if len(pr.Labels) > 0 {
 		names := make([]string, len(pr.Labels))
 		for i, l := range pr.Labels {
-			names[i] = l.Name
+			names[i] = output.Sanitize(l.Name)
 		}
 		_, _ = fmt.Fprintf(os.Stdout, "Labels:  %s\n", strings.Join(names, ", "))
 	}
 
 	if pr.Milestone != nil {
-		_, _ = fmt.Fprintf(os.Stdout, "Mile:    %s\n", pr.Milestone.Title)
+		_, _ = fmt.Fprintf(os.Stdout, "Mile:    %s\n", output.Sanitize(pr.Milestone.Title))
 	}
 
 	if pr.Additions > 0 || pr.Deletions > 0 {
@@ -124,7 +124,7 @@ func printPRDetails(pr *forges.PullRequest) {
 
 	if pr.Body != "" {
 		_, _ = fmt.Fprintln(os.Stdout)
-		_, _ = fmt.Fprintln(os.Stdout, pr.Body)
+		_, _ = fmt.Fprintln(os.Stdout, output.Sanitize(pr.Body))
 	}
 }
 
@@ -173,7 +173,7 @@ func prListCmd() *cobra.Command {
 			if p.Format == output.Plain {
 				lines := make([]string, len(prs))
 				for i, pr := range prs {
-					lines[i] = fmt.Sprintf("%d\t%s", pr.Number, pr.Title)
+					lines[i] = fmt.Sprintf("%d\t%s", pr.Number, output.Sanitize(pr.Title))
 				}
 				p.PrintPlain(lines)
 				return nil
@@ -182,14 +182,14 @@ func prListCmd() *cobra.Command {
 			headers := []string{"#", "TITLE", "AUTHOR", "HEAD", "UPDATED"}
 			rows := make([][]string, len(prs))
 			for i, pr := range prs {
-				title := pr.Title
+				title := output.Sanitize(pr.Title)
 				if len(title) > maxPRTitleLength {
 					title = title[:maxPRTitleLength-3] + "..."
 				}
 				rows[i] = []string{
 					strconv.Itoa(pr.Number),
 					title,
-					pr.Author.Login,
+					output.Sanitize(pr.Author.Login),
 					pr.Head,
 					pr.UpdatedAt.Format("2006-01-02"),
 				}

--- a/internal/cli/release.go
+++ b/internal/cli/release.go
@@ -74,8 +74,8 @@ func releaseListCmd() *cobra.Command {
 					published = r.PublishedAt.Format("2006-01-02")
 				}
 				rows[i] = []string{
-					r.TagName,
-					r.Title,
+					output.Sanitize(r.TagName),
+					output.Sanitize(r.Title),
 					fmt.Sprintf("%v", r.Draft),
 					fmt.Sprintf("%v", r.Prerelease),
 					published,
@@ -113,7 +113,7 @@ func releaseViewCmd() *cobra.Command {
 				return p.PrintJSON(release)
 			}
 
-			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", release.TagName, release.Title)
+			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", output.Sanitize(release.TagName), output.Sanitize(release.Title))
 			if release.Draft {
 				_, _ = fmt.Fprintln(os.Stdout, "Draft: true")
 			}
@@ -131,13 +131,13 @@ func releaseViewCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(os.Stdout)
 				_, _ = fmt.Fprintln(os.Stdout, "Assets:")
 				for _, a := range release.Assets {
-					_, _ = fmt.Fprintf(os.Stdout, "  %s (%d bytes)\n", a.Name, a.Size)
+					_, _ = fmt.Fprintf(os.Stdout, "  %s (%d bytes)\n", output.Sanitize(a.Name), a.Size)
 				}
 			}
 
 			if release.Body != "" {
 				_, _ = fmt.Fprintln(os.Stdout)
-				_, _ = fmt.Fprintln(os.Stdout, release.Body)
+				_, _ = fmt.Fprintln(os.Stdout, output.Sanitize(release.Body))
 			}
 
 			return nil
@@ -194,7 +194,7 @@ func releaseCreateCmd() *cobra.Command {
 				return p.PrintJSON(release)
 			}
 
-			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", release.TagName, release.Title)
+			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", output.Sanitize(release.TagName), output.Sanitize(release.Title))
 			if release.HTMLURL != "" {
 				_, _ = fmt.Fprintln(os.Stdout, release.HTMLURL)
 			}
@@ -264,7 +264,7 @@ func releaseEditCmd() *cobra.Command {
 				return p.PrintJSON(release)
 			}
 
-			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", release.TagName, release.Title)
+			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", output.Sanitize(release.TagName), output.Sanitize(release.Title))
 			return nil
 		},
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -73,9 +73,9 @@ func repoViewCmd() *cobra.Command {
 				return p.PrintJSON(r)
 			}
 
-			_, _ = fmt.Fprintf(os.Stdout, "%s\n", r.FullName)
+			_, _ = fmt.Fprintf(os.Stdout, "%s\n", output.Sanitize(r.FullName))
 			if r.Description != "" {
-				_, _ = fmt.Fprintf(os.Stdout, "%s\n", r.Description)
+				_, _ = fmt.Fprintf(os.Stdout, "%s\n", output.Sanitize(r.Description))
 			}
 			_, _ = fmt.Fprintln(os.Stdout)
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"text/tabwriter"
+	"unicode"
 )
 
 // Format specifies how to render output.
@@ -60,4 +61,16 @@ func (p *Printer) PrintPlain(lines []string) {
 	for _, line := range lines {
 		_, _ = fmt.Fprintln(p.Out, line)
 	}
+}
+
+// Sanitize strips C0 control characters (except tab and newline) from s.
+// This prevents ANSI escape sequences and OSC commands in forge-sourced
+// text from manipulating the terminal.
+func Sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r != '\t' && r != '\n' && unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -77,3 +77,27 @@ func TestPrintPlain(t *testing.T) {
 		t.Error("expected line2 in output")
 	}
 }
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"preserves tabs", "col1\tcol2", "col1\tcol2"},
+		{"preserves newlines", "line1\nline2", "line1\nline2"},
+		{"strips ESC", "normal\x1b[31mred\x1b[0m", "normal[31mred[0m"},
+		{"strips BEL", "title\x07", "title"},
+		{"strips OSC", "\x1b]0;pwned\x07", "]0;pwned"},
+		{"strips null", "a\x00b", "ab"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Sanitize(tt.input)
+			if got != tt.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue/PR titles, bodies, comments, labels, release tags, and other forge-sourced strings could contain ANSI escape or OSC sequences that manipulate the terminal (spoofed output, title changes, clipboard writes on terminals with OSC 52 enabled).

Adds \`output.Sanitize()\` which strips C0 control bytes except tab and newline, and applies it to all display paths in the issue, PR, release, and repo CLI commands. JSON output is unaffected since \`encoding/json\` already escapes control bytes.