### PR TITLE
Replace labels on gitea/forgejo issue Update

### DIFF
--- a/gitea/issues.go
+++ b/gitea/issues.go
@@ -217,6 +217,19 @@ func (s *giteaIssueService) Update(ctx context.Context, owner, repo string, numb
 		changed = true
 	}
 
+	if opts.Labels != nil {
+		ids, err := s.resolveLabelIDs(owner, repo, opts.Labels)
+		if err != nil {
+			return nil, fmt.Errorf("resolving labels: %w", err)
+		}
+		if _, _, err := s.client.ReplaceIssueLabels(owner, repo, int64(number), gitea.IssueLabelsOption{Labels: ids}); err != nil {
+			return nil, fmt.Errorf("replacing labels: %w", err)
+		}
+		if !changed {
+			return s.Get(ctx, owner, repo, number)
+		}
+	}
+
 	if !changed {
 		return s.Get(ctx, owner, repo, number)
 	}

--- a/gitea/issues_test.go
+++ b/gitea/issues_test.go
@@ -1,0 +1,64 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	forge "github.com/git-pkgs/forge"
+)
+
+func TestGiteaUpdateIssueReplacesLabels(t *testing.T) {
+	var replaceCalled bool
+	var replaceBody struct {
+		Labels []int64 `json:"labels"`
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", giteaVersionHandler)
+	mux.HandleFunc("GET /api/v1/repos/octocat/hello-world/labels", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 7, "name": "ready-for-agent", "color": "#0e8a16"},
+			{"id": 8, "name": "needs-triage", "color": "#ededed"},
+		})
+	})
+	mux.HandleFunc("PUT /api/v1/repos/octocat/hello-world/issues/42/labels", func(w http.ResponseWriter, r *http.Request) {
+		replaceCalled = true
+		_ = json.NewDecoder(r.Body).Decode(&replaceBody)
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 7, "name": "ready-for-agent", "color": "#0e8a16"},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/repos/octocat/hello-world/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 42,
+			"title":  "the issue",
+			"state":  "open",
+			"labels": []map[string]any{
+				{"id": 7, "name": "ready-for-agent", "color": "#0e8a16"},
+			},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f := New(srv.URL, "test-token", nil)
+	issue, err := f.Issues().Update(context.Background(), "octocat", "hello-world", 42, forge.UpdateIssueOpts{
+		Labels: []string{"ready-for-agent"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !replaceCalled {
+		t.Fatal("expected ReplaceIssueLabels (PUT /issues/42/labels) to be called")
+	}
+	if len(replaceBody.Labels) != 1 || replaceBody.Labels[0] != 7 {
+		t.Errorf("expected PUT body labels=[7], got %v", replaceBody.Labels)
+	}
+	if len(issue.Labels) != 1 || issue.Labels[0].Name != "ready-for-agent" {
+		t.Errorf("expected returned issue to have label ready-for-agent, got %+v", issue.Labels)
+	}
+}


### PR DESCRIPTION
## Summary

`forge issue edit <n> -l <label>` is currently a silent no-op against Gitea and Forgejo. The CLI flag is wired through to `gitea/issues.go:Update`, but the adapter sets `gitea.EditIssueOption{}` only from `opts.Title`, `opts.Body`, `opts.Assignees`, and `opts.Milestone` — `opts.Labels` is never read. The HTTP call succeeds and the returned issue reflects no label change, so callers see success but labels stay as they were.

`gitea.EditIssue` itself doesn't take labels — Gitea splits issue edits from label management. Labels go through the separate `PUT /repos/{o}/{r}/issues/{n}/labels` endpoint exposed in the SDK as `ReplaceIssueLabels`.

This PR adds a `Labels` branch in `Update` that mirrors the pattern already used by `Create`: resolve names → IDs via the existing `resolveLabelIDs` helper, then call `ReplaceIssueLabels`. When labels are the only change requested, we refetch via `s.Get` rather than make a no-op `EditIssue` call.

## Changes

- `gitea/issues.go` — 13 lines added inside `Update`, no other code paths touched.
- `gitea/issues_test.go` — new file, one focused test that asserts the PUT fires with the resolved label IDs and the returned issue reflects the new labels.

## Notes

- Same adapter is used for Gitea and Forgejo (both go through `forge-type: gitea`/`forgejo`), so the fix benefits both.
- Empty slice (`Labels: []string{}`) clears all labels, matching `ReplaceIssueLabels` semantics.
- An unknown label name produces a clear error from `resolveLabelIDs` (`labels not found: …`), so `forge issue edit -l does-not-exist` no longer silently succeeds either.

## Test plan

- [x] `go test ./...` passes (full suite, all packages)
- [x] New test `TestGiteaUpdateIssueReplacesLabels` passes
- [x] Verified end-to-end against a live Forgejo instance (`code.bas.es`): `forge issue edit <n> -l ready-for-agent` now actually replaces labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)