### PR TITLE
Resolve milestone by name on gitea issue Create/Update

### DIFF
--- a/gitea/issues.go
+++ b/gitea/issues.go
@@ -188,6 +188,13 @@ func (s *giteaIssueService) Create(ctx context.Context, owner, repo string, opts
 		}
 		gOpts.Labels = ids
 	}
+	if opts.Milestone != "" {
+		id, err := resolveMilestoneID(s.client, owner, repo, opts.Milestone)
+		if err != nil {
+			return nil, fmt.Errorf("resolving milestone: %w", err)
+		}
+		gOpts.Milestone = id
+	}
 
 	i, resp, err := s.client.CreateIssue(owner, repo, gOpts)
 	if err != nil {
@@ -214,6 +221,14 @@ func (s *giteaIssueService) Update(ctx context.Context, owner, repo string, numb
 	}
 	if opts.Assignees != nil {
 		gOpts.Assignees = opts.Assignees
+		changed = true
+	}
+	if opts.Milestone != nil {
+		id, err := resolveMilestoneID(s.client, owner, repo, *opts.Milestone)
+		if err != nil {
+			return nil, fmt.Errorf("resolving milestone: %w", err)
+		}
+		gOpts.Milestone = &id
 		changed = true
 	}
 

--- a/gitea/issues_test.go
+++ b/gitea/issues_test.go
@@ -62,3 +62,136 @@ func TestGiteaUpdateIssueReplacesLabels(t *testing.T) {
 		t.Errorf("expected returned issue to have label ready-for-agent, got %+v", issue.Labels)
 	}
 }
+
+func TestGiteaCreateIssueWithMilestone(t *testing.T) {
+	var createBody struct {
+		Title     string `json:"title"`
+		Milestone int64  `json:"milestone"`
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", giteaVersionHandler)
+	mux.HandleFunc("GET /api/v1/repos/octocat/hello-world/milestones/v1.0", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 3, "title": "v1.0", "state": "open"})
+	})
+	mux.HandleFunc("POST /api/v1/repos/octocat/hello-world/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&createBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number":    42,
+			"title":     createBody.Title,
+			"state":     "open",
+			"milestone": map[string]any{"id": 3, "title": "v1.0", "state": "open"},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f := New(srv.URL, "test-token", nil)
+	issue, err := f.Issues().Create(context.Background(), "octocat", "hello-world", forge.CreateIssueOpts{
+		Title:     "the issue",
+		Milestone: "v1.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if createBody.Milestone != 3 {
+		t.Errorf("expected POST body milestone=3, got %d", createBody.Milestone)
+	}
+	if issue.Milestone == nil || issue.Milestone.Title != "v1.0" {
+		t.Errorf("expected returned issue to have milestone v1.0, got %+v", issue.Milestone)
+	}
+}
+
+func TestGiteaUpdateIssueSetsMilestone(t *testing.T) {
+	var editCalled bool
+	var editBody struct {
+		Milestone *int64 `json:"milestone"`
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", giteaVersionHandler)
+	mux.HandleFunc("GET /api/v1/repos/octocat/hello-world/milestones/v1.0", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 3, "title": "v1.0", "state": "open"})
+	})
+	mux.HandleFunc("PATCH /api/v1/repos/octocat/hello-world/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		editCalled = true
+		_ = json.NewDecoder(r.Body).Decode(&editBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number":    42,
+			"title":     "the issue",
+			"state":     "open",
+			"milestone": map[string]any{"id": 3, "title": "v1.0", "state": "open"},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f := New(srv.URL, "test-token", nil)
+	ms := "v1.0"
+	issue, err := f.Issues().Update(context.Background(), "octocat", "hello-world", 42, forge.UpdateIssueOpts{
+		Milestone: &ms,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !editCalled {
+		t.Fatal("expected EditIssue (PATCH /issues/42) to be called")
+	}
+	if editBody.Milestone == nil || *editBody.Milestone != 3 {
+		t.Errorf("expected PATCH body milestone=3, got %v", editBody.Milestone)
+	}
+	if issue.Milestone == nil || issue.Milestone.Title != "v1.0" {
+		t.Errorf("expected returned issue to have milestone v1.0, got %+v", issue.Milestone)
+	}
+}
+
+func TestGiteaUpdateIssueClearsMilestone(t *testing.T) {
+	var editBody struct {
+		Milestone *int64 `json:"milestone"`
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", giteaVersionHandler)
+	mux.HandleFunc("PATCH /api/v1/repos/octocat/hello-world/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&editBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"number": 42, "title": "the issue", "state": "open"})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f := New(srv.URL, "test-token", nil)
+	ms := ""
+	_, err := f.Issues().Update(context.Background(), "octocat", "hello-world", 42, forge.UpdateIssueOpts{
+		Milestone: &ms,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if editBody.Milestone == nil || *editBody.Milestone != 0 {
+		t.Errorf("expected PATCH body milestone=0 (clear), got %v", editBody.Milestone)
+	}
+}
+
+func TestGiteaUpdateIssueUnknownMilestone(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", giteaVersionHandler)
+	mux.HandleFunc("GET /api/v1/repos/octocat/hello-world/milestones/nope", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f := New(srv.URL, "test-token", nil)
+	ms := "nope"
+	_, err := f.Issues().Update(context.Background(), "octocat", "hello-world", 42, forge.UpdateIssueOpts{
+		Milestone: &ms,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown milestone")
+	}
+}

--- a/gitea/milestones.go
+++ b/gitea/milestones.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"context"
+	"fmt"
 	forge "github.com/git-pkgs/forge"
 	"net/http"
 
@@ -84,6 +85,20 @@ func (s *giteaMilestoneService) List(ctx context.Context, owner, repo string, op
 	}
 
 	return all, nil
+}
+
+func resolveMilestoneID(client *gitea.Client, owner, repo, name string) (int64, error) {
+	if name == "" {
+		return 0, nil
+	}
+	m, resp, err := client.GetMilestoneByName(owner, repo, name)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return 0, fmt.Errorf("milestone not found: %s", name)
+		}
+		return 0, err
+	}
+	return m.ID, nil
 }
 
 func (s *giteaMilestoneService) Get(ctx context.Context, owner, repo string, id int) (*forge.Milestone, error) {


### PR DESCRIPTION
Fixes #76.

`forge issue create -m <milestone>` and `forge issue edit <n> -m <milestone>` were silent no-ops against Gitea/Forgejo because `giteaIssueService.Create` and `Update` never read `opts.Milestone`. Same class of bug as #75.

Unlike labels, `gitea.CreateIssueOption` and `gitea.EditIssueOption` already have a `Milestone` field, so this goes through the existing calls rather than a separate endpoint. The SDK provides `GetMilestoneByName` so the title-to-ID resolver is a single lookup rather than a paginated scan.

Empty string on `Update` sends `milestone: 0` to clear the assignment. An unknown title produces `milestone not found: <name>` instead of silently succeeding.

The `Update` branch is placed before the existing labels block so that setting both `-l` and `-m` together still reaches `EditIssue` after `ReplaceIssueLabels` fires.