### PR TITLE
Set goconst to ignore test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,8 @@ version: "2"
 formatters:
   enable:
     - gofmt
+
+linters:
+  settings:
+    goconst:
+      ignore-tests: true


### PR DESCRIPTION
Path exclusions only filter where goconst issues are reported, not which files contribute to the occurrence count, so a string used once in production code and twice in tests still gets flagged. The `ignore-tests` setting makes goconst skip test files entirely.