### PR TITLE
Fix browse <path> URL on non-GitHub forges

### DIFF
--- a/bitbucket/bitbucket.go
+++ b/bitbucket/bitbucket.go
@@ -386,3 +386,7 @@ func (s *bitbucketRepoService) ActionsURL(repoHTMLURL string) string {
 func (s *bitbucketRepoService) ReleasesURL(repoHTMLURL string) string {
 	return repoHTMLURL + "/downloads"
 }
+
+func (s *bitbucketRepoService) BlobURL(repoHTMLURL, ref, path string) string {
+	return repoHTMLURL + "/src/" + ref + "/" + path
+}

--- a/bitbucket/urls_test.go
+++ b/bitbucket/urls_test.go
@@ -1,0 +1,12 @@
+package bitbucket
+
+import "testing"
+
+func TestBitbucketRepoBlobURL(t *testing.T) {
+	s := &bitbucketRepoService{}
+	got := s.BlobURL("https://bitbucket.org/owner/repo", "master", "README.md")
+	want := "https://bitbucket.org/owner/repo/src/master/README.md"
+	if got != want {
+		t.Errorf("BlobURL = %q, want %q", got, want)
+	}
+}

--- a/forges_test.go
+++ b/forges_test.go
@@ -618,6 +618,10 @@ func (m *mockRepoService) ReleasesURL(repoHTMLURL string) string {
 	return repoHTMLURL + "/releases"
 }
 
+func (m *mockRepoService) BlobURL(repoHTMLURL, ref, path string) string {
+	return repoHTMLURL + "/blob/" + ref + "/" + path
+}
+
 type mockIssueService struct {
 	issue      *Issue
 	issues     []Issue

--- a/gitea/gitea.go
+++ b/gitea/gitea.go
@@ -416,4 +416,8 @@ func (s *giteaRepoService) ReleasesURL(repoHTMLURL string) string {
 	return repoHTMLURL + "/releases"
 }
 
+func (s *giteaRepoService) BlobURL(repoHTMLURL, ref, path string) string {
+	return repoHTMLURL + "/src/branch/" + ref + "/" + path
+}
+
 func boolPtr(b bool) *bool { return &b }

--- a/gitea/urls_test.go
+++ b/gitea/urls_test.go
@@ -1,0 +1,12 @@
+package gitea
+
+import "testing"
+
+func TestGiteaRepoBlobURL(t *testing.T) {
+	s := &giteaRepoService{}
+	got := s.BlobURL("https://codeberg.org/owner/repo", "main", "README.md")
+	want := "https://codeberg.org/owner/repo/src/branch/main/README.md"
+	if got != want {
+		t.Errorf("BlobURL = %q, want %q", got, want)
+	}
+}

--- a/github/github.go
+++ b/github/github.go
@@ -445,3 +445,7 @@ func (s *gitHubRepoService) ActionsURL(repoHTMLURL string) string {
 func (s *gitHubRepoService) ReleasesURL(repoHTMLURL string) string {
 	return repoHTMLURL + "/releases"
 }
+
+func (s *gitHubRepoService) BlobURL(repoHTMLURL, ref, path string) string {
+	return repoHTMLURL + "/blob/" + ref + "/" + path
+}

--- a/github/urls_test.go
+++ b/github/urls_test.go
@@ -1,0 +1,12 @@
+package github
+
+import "testing"
+
+func TestGitHubRepoBlobURL(t *testing.T) {
+	s := &gitHubRepoService{}
+	got := s.BlobURL("https://github.com/owner/repo", "main", "cmd/main.go")
+	want := "https://github.com/owner/repo/blob/main/cmd/main.go"
+	if got != want {
+		t.Errorf("BlobURL = %q, want %q", got, want)
+	}
+}

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -432,3 +432,7 @@ func (s *gitLabRepoService) ActionsURL(repoHTMLURL string) string {
 func (s *gitLabRepoService) ReleasesURL(repoHTMLURL string) string {
 	return repoHTMLURL + "/-/releases"
 }
+
+func (s *gitLabRepoService) BlobURL(repoHTMLURL, ref, path string) string {
+	return repoHTMLURL + "/-/blob/" + ref + "/" + path
+}

--- a/gitlab/urls_test.go
+++ b/gitlab/urls_test.go
@@ -1,0 +1,12 @@
+package gitlab
+
+import "testing"
+
+func TestGitLabRepoBlobURL(t *testing.T) {
+	s := &gitLabRepoService{}
+	got := s.BlobURL("https://gitlab.com/group/project", "main", "src/app.go")
+	want := "https://gitlab.com/group/project/-/blob/main/src/app.go"
+	if got != want {
+		t.Errorf("BlobURL = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/browse.go
+++ b/internal/cli/browse.go
@@ -56,7 +56,7 @@ var browseCmd = &cobra.Command{
 				if branch == "" {
 					branch = repo.DefaultBranch
 				}
-				url = repoURL + fmt.Sprintf("/blob/%s/%s", branch, args[0])
+				url = forge.Repos().BlobURL(repoURL, branch, args[0])
 			}
 		} else {
 			url = repoURL

--- a/services.go
+++ b/services.go
@@ -23,6 +23,7 @@ type RepoService interface {
 	WikiURL(repoHTMLURL string) string
 	ActionsURL(repoHTMLURL string) string
 	ReleasesURL(repoHTMLURL string) string
+	BlobURL(repoHTMLURL, ref, path string) string
 }
 
 // PullRequestService provides operations on pull requests (merge requests on GitLab).


### PR DESCRIPTION
`forge browse <path>` hardcoded `/blob/{branch}/{path}`, which only works on GitHub. GitLab wants `/-/blob/`, Gitea/Forgejo want `/src/branch/`, and Bitbucket wants `/src/`.

Adds `BlobURL(repoHTMLURL, ref, path)` to `RepoService` following the URL-builder pattern from #91 and wires `browse` onto it.

The Gitea path assumes `ref` is a branch name. Tags and commit SHAs use `/src/tag/` and `/src/commit/` respectively, but `-b` is documented as a branch flag and disambiguating would need an extra API round-trip.