### PR TITLE
Support URLs in forge pr checkout

### DIFF
--- a/bitbucket/url.go
+++ b/bitbucket/url.go
@@ -3,38 +3,35 @@ package bitbucket
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/git-pkgs/forge"
 )
 
 // ParsePath implements Forge.ParsePath for Bitbucket URLs.
-func (f *bitbucketForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
-	return parsePath(parts)
-}
-
-// parsePath parses Bitbucket URL path segments into resource components.
-// Formats: owner/repo, owner/repo/pull-requests/123, owner/repo/issues/456
-func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+func (f *bitbucketForge) ParsePath(parts []string) (*forges.ResourceRef, error) {
 	if len(parts) < 2 {
-		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+		return nil, fmt.Errorf("URL path must contain owner/repo")
 	}
 
-	owner, repo = parts[0], parts[1]
+	ref := &forges.ResourceRef{
+		Owner: parts[0],
+		Repo:  parts[1],
+	}
 
 	if len(parts) >= 4 {
+		num, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q", parts[3])
+		}
+		ref.Number = num
+
 		switch parts[2] {
 		case "pull-requests":
-			resourceType = "pr"
-			number, err = strconv.Atoi(parts[3])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid PR number %q", parts[3])
-			}
+			ref.Type = forges.ResourceTypePR
 		case "issues":
-			resourceType = "issue"
-			number, err = strconv.Atoi(parts[3])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[3])
-			}
+			ref.Type = forges.ResourceTypeIssue
 		}
 	}
 
-	return owner, repo, resourceType, number, nil
+	return ref, nil
 }

--- a/bitbucket/url.go
+++ b/bitbucket/url.go
@@ -1,0 +1,40 @@
+package bitbucket
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParsePath implements Forge.ParsePath for Bitbucket URLs.
+func (f *bitbucketForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	return parsePath(parts)
+}
+
+// parsePath parses Bitbucket URL path segments into resource components.
+// Formats: owner/repo, owner/repo/pull-requests/123, owner/repo/issues/456
+func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	if len(parts) < 2 {
+		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+	}
+
+	owner, repo = parts[0], parts[1]
+
+	if len(parts) >= 4 {
+		switch parts[2] {
+		case "pull-requests":
+			resourceType = "pr"
+			number, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid PR number %q", parts[3])
+			}
+		case "issues":
+			resourceType = "issue"
+			number, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[3])
+			}
+		}
+	}
+
+	return owner, repo, resourceType, number, nil
+}

--- a/bitbucket/url_test.go
+++ b/bitbucket/url_test.go
@@ -1,0 +1,70 @@
+package bitbucket
+
+import "testing"
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		parts        []string
+		wantOwner    string
+		wantRepo     string
+		wantResource string
+		wantNumber   int
+		wantErr      bool
+	}{
+		{
+			name:      "repo only",
+			parts:     []string{"owner", "repo"},
+			wantOwner: "owner", wantRepo: "repo",
+		},
+		{
+			name:      "pull request",
+			parts:     []string{"owner", "repo", "pull-requests", "123"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "pr", wantNumber: 123,
+		},
+		{
+			name:      "issue",
+			parts:     []string{"owner", "repo", "issues", "456"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "issue", wantNumber: 456,
+		},
+		{
+			name:    "missing repo",
+			parts:   []string{"owner"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid PR number",
+			parts:   []string{"owner", "repo", "pull-requests", "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, resource, number, err := parsePath(tt.parts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			}
+			if resource != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			}
+			if number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			}
+		})
+	}
+}

--- a/bitbucket/url_test.go
+++ b/bitbucket/url_test.go
@@ -1,6 +1,10 @@
 package bitbucket
 
-import "testing"
+import (
+	"testing"
+
+	forges "github.com/git-pkgs/forge"
+)
 
 func TestParsePath(t *testing.T) {
 	tests := []struct {
@@ -8,7 +12,7 @@ func TestParsePath(t *testing.T) {
 		parts        []string
 		wantOwner    string
 		wantRepo     string
-		wantResource string
+		wantResource forges.ResourceType
 		wantNumber   int
 		wantErr      bool
 	}{
@@ -21,13 +25,13 @@ func TestParsePath(t *testing.T) {
 			name:      "pull request",
 			parts:     []string{"owner", "repo", "pull-requests", "123"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "pr", wantNumber: 123,
+			wantResource: forges.ResourceTypePR, wantNumber: 123,
 		},
 		{
 			name:      "issue",
 			parts:     []string{"owner", "repo", "issues", "456"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "issue", wantNumber: 456,
+			wantResource: forges.ResourceTypeIssue, wantNumber: 456,
 		},
 		{
 			name:    "missing repo",
@@ -41,9 +45,10 @@ func TestParsePath(t *testing.T) {
 		},
 	}
 
+	f := &bitbucketForge{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			owner, repo, resource, number, err := parsePath(tt.parts)
+			ref, err := f.ParsePath(tt.parts)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error")
@@ -53,17 +58,17 @@ func TestParsePath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if owner != tt.wantOwner {
-				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			if ref.Owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", ref.Owner, tt.wantOwner)
 			}
-			if repo != tt.wantRepo {
-				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			if ref.Repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", ref.Repo, tt.wantRepo)
 			}
-			if resource != tt.wantResource {
-				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			if ref.Type != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", ref.Type, tt.wantResource)
 			}
-			if number != tt.wantNumber {
-				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			if ref.Number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", ref.Number, tt.wantNumber)
 			}
 		})
 	}

--- a/forge.go
+++ b/forge.go
@@ -52,6 +52,8 @@ type Forge interface {
 	Collaborators() CollaboratorService
 	CommitStatuses() CommitStatusService
 	GetRateLimit(ctx context.Context) (*RateLimit, error)
+	// ParsePath parses URL path segments into owner, repo, resource type, and number.
+	ParsePath(pathParts []string) (owner, repo, resourceType string, number int, err error)
 }
 
 // Client routes requests to the appropriate Forge based on the URL domain.

--- a/forge.go
+++ b/forge.go
@@ -23,6 +23,22 @@ var ErrNotSupported = errors.New("not supported by this forge")
 // ErrLabelExists is returned when creating a label that already exists.
 var ErrLabelExists = errors.New("label already exists")
 
+// ResourceType identifies the kind of resource a URL points to.
+type ResourceType string
+
+const (
+	ResourceTypePR    ResourceType = "pr"
+	ResourceTypeIssue ResourceType = "issue"
+)
+
+// ResourceRef identifies a resource (PR, issue, etc.) within a repository.
+type ResourceRef struct {
+	Owner  string
+	Repo   string
+	Type   ResourceType
+	Number int
+}
+
 // HTTPError represents a non-OK HTTP response from a forge API.
 type HTTPError struct {
 	StatusCode int
@@ -52,8 +68,8 @@ type Forge interface {
 	Collaborators() CollaboratorService
 	CommitStatuses() CommitStatusService
 	GetRateLimit(ctx context.Context) (*RateLimit, error)
-	// ParsePath parses URL path segments into owner, repo, resource type, and number.
-	ParsePath(pathParts []string) (owner, repo, resourceType string, number int, err error)
+	// ParsePath parses URL path segments into a resource reference.
+	ParsePath(pathParts []string) (*ResourceRef, error)
 }
 
 // Client routes requests to the appropriate Forge based on the URL domain.

--- a/forges_test.go
+++ b/forges_test.go
@@ -505,6 +505,10 @@ func (m *mockForge) GetRateLimit(_ context.Context) (*RateLimit, error) {
 	return nil, ErrNotSupported
 }
 
+func (m *mockForge) ParsePath(_ []string) (string, string, string, int, error) {
+	return "", "", "", 0, nil
+}
+
 type mockFileService struct{}
 
 func (m *mockFileService) Get(_ context.Context, _, _, _, _ string) (*FileContent, error) {

--- a/forges_test.go
+++ b/forges_test.go
@@ -505,8 +505,8 @@ func (m *mockForge) GetRateLimit(_ context.Context) (*RateLimit, error) {
 	return nil, ErrNotSupported
 }
 
-func (m *mockForge) ParsePath(_ []string) (string, string, string, int, error) {
-	return "", "", "", 0, nil
+func (m *mockForge) ParsePath(_ []string) (*ResourceRef, error) {
+	return &ResourceRef{}, nil
 }
 
 type mockFileService struct{}

--- a/gitea/url.go
+++ b/gitea/url.go
@@ -3,38 +3,35 @@ package gitea
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/git-pkgs/forge"
 )
 
 // ParsePath implements Forge.ParsePath for Gitea/Forgejo URLs.
-func (f *giteaForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
-	return parsePath(parts)
-}
-
-// parsePath parses Gitea/Forgejo URL path segments into resource components.
-// Formats: owner/repo, owner/repo/pulls/123, owner/repo/issues/456
-func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+func (f *giteaForge) ParsePath(parts []string) (*forges.ResourceRef, error) {
 	if len(parts) < 2 {
-		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+		return nil, fmt.Errorf("URL path must contain owner/repo")
 	}
 
-	owner, repo = parts[0], parts[1]
+	ref := &forges.ResourceRef{
+		Owner: parts[0],
+		Repo:  parts[1],
+	}
 
 	if len(parts) >= 4 {
+		num, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q", parts[3])
+		}
+		ref.Number = num
+
 		switch parts[2] {
 		case "pulls":
-			resourceType = "pr"
-			number, err = strconv.Atoi(parts[3])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid PR number %q", parts[3])
-			}
+			ref.Type = forges.ResourceTypePR
 		case "issues":
-			resourceType = "issue"
-			number, err = strconv.Atoi(parts[3])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[3])
-			}
+			ref.Type = forges.ResourceTypeIssue
 		}
 	}
 
-	return owner, repo, resourceType, number, nil
+	return ref, nil
 }

--- a/gitea/url.go
+++ b/gitea/url.go
@@ -1,0 +1,40 @@
+package gitea
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParsePath implements Forge.ParsePath for Gitea/Forgejo URLs.
+func (f *giteaForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	return parsePath(parts)
+}
+
+// parsePath parses Gitea/Forgejo URL path segments into resource components.
+// Formats: owner/repo, owner/repo/pulls/123, owner/repo/issues/456
+func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	if len(parts) < 2 {
+		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+	}
+
+	owner, repo = parts[0], parts[1]
+
+	if len(parts) >= 4 {
+		switch parts[2] {
+		case "pulls":
+			resourceType = "pr"
+			number, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid PR number %q", parts[3])
+			}
+		case "issues":
+			resourceType = "issue"
+			number, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[3])
+			}
+		}
+	}
+
+	return owner, repo, resourceType, number, nil
+}

--- a/gitea/url_test.go
+++ b/gitea/url_test.go
@@ -1,6 +1,10 @@
 package gitea
 
-import "testing"
+import (
+	"testing"
+
+	forges "github.com/git-pkgs/forge"
+)
 
 func TestParsePath(t *testing.T) {
 	tests := []struct {
@@ -8,7 +12,7 @@ func TestParsePath(t *testing.T) {
 		parts        []string
 		wantOwner    string
 		wantRepo     string
-		wantResource string
+		wantResource forges.ResourceType
 		wantNumber   int
 		wantErr      bool
 	}{
@@ -21,13 +25,13 @@ func TestParsePath(t *testing.T) {
 			name:      "pull request",
 			parts:     []string{"owner", "repo", "pulls", "123"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "pr", wantNumber: 123,
+			wantResource: forges.ResourceTypePR, wantNumber: 123,
 		},
 		{
 			name:      "issue",
 			parts:     []string{"owner", "repo", "issues", "456"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "issue", wantNumber: 456,
+			wantResource: forges.ResourceTypeIssue, wantNumber: 456,
 		},
 		{
 			name:    "missing repo",
@@ -41,9 +45,10 @@ func TestParsePath(t *testing.T) {
 		},
 	}
 
+	f := &giteaForge{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			owner, repo, resource, number, err := parsePath(tt.parts)
+			ref, err := f.ParsePath(tt.parts)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error")
@@ -53,17 +58,17 @@ func TestParsePath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if owner != tt.wantOwner {
-				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			if ref.Owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", ref.Owner, tt.wantOwner)
 			}
-			if repo != tt.wantRepo {
-				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			if ref.Repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", ref.Repo, tt.wantRepo)
 			}
-			if resource != tt.wantResource {
-				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			if ref.Type != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", ref.Type, tt.wantResource)
 			}
-			if number != tt.wantNumber {
-				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			if ref.Number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", ref.Number, tt.wantNumber)
 			}
 		})
 	}

--- a/gitea/url_test.go
+++ b/gitea/url_test.go
@@ -1,0 +1,70 @@
+package gitea
+
+import "testing"
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		parts        []string
+		wantOwner    string
+		wantRepo     string
+		wantResource string
+		wantNumber   int
+		wantErr      bool
+	}{
+		{
+			name:      "repo only",
+			parts:     []string{"owner", "repo"},
+			wantOwner: "owner", wantRepo: "repo",
+		},
+		{
+			name:      "pull request",
+			parts:     []string{"owner", "repo", "pulls", "123"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "pr", wantNumber: 123,
+		},
+		{
+			name:      "issue",
+			parts:     []string{"owner", "repo", "issues", "456"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "issue", wantNumber: 456,
+		},
+		{
+			name:    "missing repo",
+			parts:   []string{"owner"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid PR number",
+			parts:   []string{"owner", "repo", "pulls", "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, resource, number, err := parsePath(tt.parts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			}
+			if resource != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			}
+			if number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			}
+		})
+	}
+}

--- a/github/url.go
+++ b/github/url.go
@@ -3,38 +3,35 @@ package github
 import (
 	"fmt"
 	"strconv"
+
+	forges "github.com/git-pkgs/forge"
 )
 
 // ParsePath implements Forge.ParsePath for GitHub URLs.
-func (f *gitHubForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
-	return parsePath(parts)
-}
-
-// parsePath parses GitHub URL path segments into resource components.
-// Formats: owner/repo, owner/repo/pull/123, owner/repo/issues/456
-func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+func (f *gitHubForge) ParsePath(parts []string) (*forges.ResourceRef, error) {
 	if len(parts) < 2 {
-		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+		return nil, fmt.Errorf("URL path must contain owner/repo")
 	}
 
-	owner, repo = parts[0], parts[1]
+	ref := &forges.ResourceRef{
+		Owner: parts[0],
+		Repo:  parts[1],
+	}
 
 	if len(parts) >= 4 {
+		num, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q", parts[3])
+		}
+		ref.Number = num
+
 		switch parts[2] {
 		case "pull":
-			resourceType = "pr"
-			number, err = strconv.Atoi(parts[3])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid PR number %q", parts[3])
-			}
+			ref.Type = forges.ResourceTypePR
 		case "issues":
-			resourceType = "issue"
-			number, err = strconv.Atoi(parts[3])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[3])
-			}
+			ref.Type = forges.ResourceTypeIssue
 		}
 	}
 
-	return owner, repo, resourceType, number, nil
+	return ref, nil
 }

--- a/github/url.go
+++ b/github/url.go
@@ -1,0 +1,40 @@
+package github
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParsePath implements Forge.ParsePath for GitHub URLs.
+func (f *gitHubForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	return parsePath(parts)
+}
+
+// parsePath parses GitHub URL path segments into resource components.
+// Formats: owner/repo, owner/repo/pull/123, owner/repo/issues/456
+func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	if len(parts) < 2 {
+		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+	}
+
+	owner, repo = parts[0], parts[1]
+
+	if len(parts) >= 4 {
+		switch parts[2] {
+		case "pull":
+			resourceType = "pr"
+			number, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid PR number %q", parts[3])
+			}
+		case "issues":
+			resourceType = "issue"
+			number, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[3])
+			}
+		}
+	}
+
+	return owner, repo, resourceType, number, nil
+}

--- a/github/url_test.go
+++ b/github/url_test.go
@@ -1,0 +1,76 @@
+package github
+
+import "testing"
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		parts        []string
+		wantOwner    string
+		wantRepo     string
+		wantResource string
+		wantNumber   int
+		wantErr      bool
+	}{
+		{
+			name:      "repo only",
+			parts:     []string{"owner", "repo"},
+			wantOwner: "owner", wantRepo: "repo",
+		},
+		{
+			name:      "pull request",
+			parts:     []string{"owner", "repo", "pull", "123"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "pr", wantNumber: 123,
+		},
+		{
+			name:      "pull request with extra path",
+			parts:     []string{"owner", "repo", "pull", "123", "files"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "pr", wantNumber: 123,
+		},
+		{
+			name:      "issue",
+			parts:     []string{"owner", "repo", "issues", "456"},
+			wantOwner: "owner", wantRepo: "repo",
+			wantResource: "issue", wantNumber: 456,
+		},
+		{
+			name:    "missing repo",
+			parts:   []string{"owner"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid PR number",
+			parts:   []string{"owner", "repo", "pull", "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, resource, number, err := parsePath(tt.parts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			}
+			if resource != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			}
+			if number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			}
+		})
+	}
+}

--- a/github/url_test.go
+++ b/github/url_test.go
@@ -1,6 +1,10 @@
 package github
 
-import "testing"
+import (
+	"testing"
+
+	forges "github.com/git-pkgs/forge"
+)
 
 func TestParsePath(t *testing.T) {
 	tests := []struct {
@@ -8,7 +12,7 @@ func TestParsePath(t *testing.T) {
 		parts        []string
 		wantOwner    string
 		wantRepo     string
-		wantResource string
+		wantResource forges.ResourceType
 		wantNumber   int
 		wantErr      bool
 	}{
@@ -21,19 +25,19 @@ func TestParsePath(t *testing.T) {
 			name:      "pull request",
 			parts:     []string{"owner", "repo", "pull", "123"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "pr", wantNumber: 123,
+			wantResource: forges.ResourceTypePR, wantNumber: 123,
 		},
 		{
 			name:      "pull request with extra path",
 			parts:     []string{"owner", "repo", "pull", "123", "files"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "pr", wantNumber: 123,
+			wantResource: forges.ResourceTypePR, wantNumber: 123,
 		},
 		{
 			name:      "issue",
 			parts:     []string{"owner", "repo", "issues", "456"},
 			wantOwner: "owner", wantRepo: "repo",
-			wantResource: "issue", wantNumber: 456,
+			wantResource: forges.ResourceTypeIssue, wantNumber: 456,
 		},
 		{
 			name:    "missing repo",
@@ -47,9 +51,10 @@ func TestParsePath(t *testing.T) {
 		},
 	}
 
+	f := &gitHubForge{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			owner, repo, resource, number, err := parsePath(tt.parts)
+			ref, err := f.ParsePath(tt.parts)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error")
@@ -59,17 +64,17 @@ func TestParsePath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if owner != tt.wantOwner {
-				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			if ref.Owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", ref.Owner, tt.wantOwner)
 			}
-			if repo != tt.wantRepo {
-				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			if ref.Repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", ref.Repo, tt.wantRepo)
 			}
-			if resource != tt.wantResource {
-				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			if ref.Type != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", ref.Type, tt.wantResource)
 			}
-			if number != tt.wantNumber {
-				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			if ref.Number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", ref.Number, tt.wantNumber)
 			}
 		})
 	}

--- a/gitlab/url.go
+++ b/gitlab/url.go
@@ -4,18 +4,14 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/git-pkgs/forge"
 )
 
 // ParsePath implements Forge.ParsePath for GitLab URLs.
-func (f *gitLabForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
-	return parsePath(parts)
-}
-
-// parsePath parses GitLab URL path segments into resource components.
-// Formats: group/project, group/subgroup/project, group/project/-/merge_requests/123
-func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+func (f *gitLabForge) ParsePath(parts []string) (*forges.ResourceRef, error) {
 	if len(parts) < 2 {
-		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+		return nil, fmt.Errorf("URL path must contain owner/repo")
 	}
 
 	// Find /-/ separator marking resource paths
@@ -27,34 +23,34 @@ func parsePath(parts []string) (owner, repo, resourceType string, number int, er
 		}
 	}
 
+	ref := &forges.ResourceRef{}
+
 	if dashIdx == -1 {
-		owner = strings.Join(parts[:len(parts)-1], "/")
-		repo = parts[len(parts)-1]
-		return owner, repo, "", 0, nil
+		ref.Owner = strings.Join(parts[:len(parts)-1], "/")
+		ref.Repo = parts[len(parts)-1]
+		return ref, nil
 	}
 
 	if dashIdx < 2 {
-		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo before /-/")
+		return nil, fmt.Errorf("URL path must contain owner/repo before /-/")
 	}
-	owner = strings.Join(parts[:dashIdx-1], "/")
-	repo = parts[dashIdx-1]
+	ref.Owner = strings.Join(parts[:dashIdx-1], "/")
+	ref.Repo = parts[dashIdx-1]
 
 	if dashIdx+2 < len(parts) {
+		num, err := strconv.Atoi(parts[dashIdx+2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q", parts[dashIdx+2])
+		}
+		ref.Number = num
+
 		switch parts[dashIdx+1] {
 		case "merge_requests":
-			resourceType = "pr"
-			number, err = strconv.Atoi(parts[dashIdx+2])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid MR number %q", parts[dashIdx+2])
-			}
+			ref.Type = forges.ResourceTypePR
 		case "issues":
-			resourceType = "issue"
-			number, err = strconv.Atoi(parts[dashIdx+2])
-			if err != nil {
-				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[dashIdx+2])
-			}
+			ref.Type = forges.ResourceTypeIssue
 		}
 	}
 
-	return owner, repo, resourceType, number, nil
+	return ref, nil
 }

--- a/gitlab/url.go
+++ b/gitlab/url.go
@@ -1,0 +1,60 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParsePath implements Forge.ParsePath for GitLab URLs.
+func (f *gitLabForge) ParsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	return parsePath(parts)
+}
+
+// parsePath parses GitLab URL path segments into resource components.
+// Formats: group/project, group/subgroup/project, group/project/-/merge_requests/123
+func parsePath(parts []string) (owner, repo, resourceType string, number int, err error) {
+	if len(parts) < 2 {
+		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo")
+	}
+
+	// Find /-/ separator marking resource paths
+	dashIdx := -1
+	for i, part := range parts {
+		if part == "-" {
+			dashIdx = i
+			break
+		}
+	}
+
+	if dashIdx == -1 {
+		owner = strings.Join(parts[:len(parts)-1], "/")
+		repo = parts[len(parts)-1]
+		return owner, repo, "", 0, nil
+	}
+
+	if dashIdx < 2 {
+		return "", "", "", 0, fmt.Errorf("URL path must contain owner/repo before /-/")
+	}
+	owner = strings.Join(parts[:dashIdx-1], "/")
+	repo = parts[dashIdx-1]
+
+	if dashIdx+2 < len(parts) {
+		switch parts[dashIdx+1] {
+		case "merge_requests":
+			resourceType = "pr"
+			number, err = strconv.Atoi(parts[dashIdx+2])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid MR number %q", parts[dashIdx+2])
+			}
+		case "issues":
+			resourceType = "issue"
+			number, err = strconv.Atoi(parts[dashIdx+2])
+			if err != nil {
+				return "", "", "", 0, fmt.Errorf("invalid issue number %q", parts[dashIdx+2])
+			}
+		}
+	}
+
+	return owner, repo, resourceType, number, nil
+}

--- a/gitlab/url_test.go
+++ b/gitlab/url_test.go
@@ -1,6 +1,10 @@
 package gitlab
 
-import "testing"
+import (
+	"testing"
+
+	forges "github.com/git-pkgs/forge"
+)
 
 func TestParsePath(t *testing.T) {
 	tests := []struct {
@@ -8,7 +12,7 @@ func TestParsePath(t *testing.T) {
 		parts        []string
 		wantOwner    string
 		wantRepo     string
-		wantResource string
+		wantResource forges.ResourceType
 		wantNumber   int
 		wantErr      bool
 	}{
@@ -26,19 +30,19 @@ func TestParsePath(t *testing.T) {
 			name:      "merge request",
 			parts:     []string{"group", "project", "-", "merge_requests", "123"},
 			wantOwner: "group", wantRepo: "project",
-			wantResource: "pr", wantNumber: 123,
+			wantResource: forges.ResourceTypePR, wantNumber: 123,
 		},
 		{
 			name:      "nested group merge request",
 			parts:     []string{"group", "subgroup", "project", "-", "merge_requests", "123"},
 			wantOwner: "group/subgroup", wantRepo: "project",
-			wantResource: "pr", wantNumber: 123,
+			wantResource: forges.ResourceTypePR, wantNumber: 123,
 		},
 		{
 			name:      "issue",
 			parts:     []string{"group", "project", "-", "issues", "456"},
 			wantOwner: "group", wantRepo: "project",
-			wantResource: "issue", wantNumber: 456,
+			wantResource: forges.ResourceTypeIssue, wantNumber: 456,
 		},
 		{
 			name:    "missing repo",
@@ -52,9 +56,10 @@ func TestParsePath(t *testing.T) {
 		},
 	}
 
+	f := &gitLabForge{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			owner, repo, resource, number, err := parsePath(tt.parts)
+			ref, err := f.ParsePath(tt.parts)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error")
@@ -64,17 +69,17 @@ func TestParsePath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if owner != tt.wantOwner {
-				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			if ref.Owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", ref.Owner, tt.wantOwner)
 			}
-			if repo != tt.wantRepo {
-				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			if ref.Repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", ref.Repo, tt.wantRepo)
 			}
-			if resource != tt.wantResource {
-				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			if ref.Type != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", ref.Type, tt.wantResource)
 			}
-			if number != tt.wantNumber {
-				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			if ref.Number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", ref.Number, tt.wantNumber)
 			}
 		})
 	}

--- a/gitlab/url_test.go
+++ b/gitlab/url_test.go
@@ -1,0 +1,81 @@
+package gitlab
+
+import "testing"
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		parts        []string
+		wantOwner    string
+		wantRepo     string
+		wantResource string
+		wantNumber   int
+		wantErr      bool
+	}{
+		{
+			name:      "repo only",
+			parts:     []string{"group", "project"},
+			wantOwner: "group", wantRepo: "project",
+		},
+		{
+			name:      "nested group",
+			parts:     []string{"group", "subgroup", "project"},
+			wantOwner: "group/subgroup", wantRepo: "project",
+		},
+		{
+			name:      "merge request",
+			parts:     []string{"group", "project", "-", "merge_requests", "123"},
+			wantOwner: "group", wantRepo: "project",
+			wantResource: "pr", wantNumber: 123,
+		},
+		{
+			name:      "nested group merge request",
+			parts:     []string{"group", "subgroup", "project", "-", "merge_requests", "123"},
+			wantOwner: "group/subgroup", wantRepo: "project",
+			wantResource: "pr", wantNumber: 123,
+		},
+		{
+			name:      "issue",
+			parts:     []string{"group", "project", "-", "issues", "456"},
+			wantOwner: "group", wantRepo: "project",
+			wantResource: "issue", wantNumber: 456,
+		},
+		{
+			name:    "missing repo",
+			parts:   []string{"group"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid MR number",
+			parts:   []string{"group", "project", "-", "merge_requests", "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, resource, number, err := parsePath(tt.parts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner: got %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			}
+			if resource != tt.wantResource {
+				t.Errorf("resource: got %q, want %q", resource, tt.wantResource)
+			}
+			if number != tt.wantNumber {
+				t.Errorf("number: got %d, want %d", number, tt.wantNumber)
+			}
+		})
+	}
+}

--- a/internal/cli/collaborator.go
+++ b/internal/cli/collaborator.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"

--- a/internal/cli/label.go
+++ b/internal/cli/label.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"

--- a/internal/cli/notification.go
+++ b/internal/cli/notification.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -583,14 +583,15 @@ The argument can be a PR number or a full URL:
 				}
 			} else {
 				// Try parsing as a URL
-				var resourceType string
-				forge, owner, repoName, domain, resourceType, number, err = resolve.ResourceFromURL(args[0])
+				var ref *forges.ResourceRef
+				forge, domain, ref, err = resolve.ResourceFromURL(args[0])
 				if err != nil {
 					return fmt.Errorf("invalid PR number or URL %q: %w", args[0], err)
 				}
-				if resourceType != "pr" {
+				if ref.Type != forges.ResourceTypePR {
 					return fmt.Errorf("URL does not point to a pull request: %s", args[0])
 				}
+				owner, repoName, number = ref.Owner, ref.Repo, ref.Number
 			}
 
 			ctx := cmd.Context()

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"
@@ -586,7 +586,7 @@ The argument can be a PR number or a full URL:
 				var resourceType string
 				forge, owner, repoName, domain, resourceType, number, err = resolve.ResourceFromURL(args[0])
 				if err != nil {
-					return fmt.Errorf("invalid PR number or URL: %s", args[0])
+					return fmt.Errorf("invalid PR number or URL %q: %w", args[0], err)
 				}
 				if resourceType != "pr" {
 					return fmt.Errorf("URL does not point to a pull request: %s", args[0])

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -551,7 +551,7 @@ func prCheckoutCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "checkout <number>",
+		Use:   "checkout <number-or-url>",
 		Short: "Check out a pull request locally",
 		Long: `Check out a pull request's head branch locally.
 
@@ -559,17 +559,38 @@ If the PR is from a fork, the fork repository is added as a remote
 (named after the fork owner by default), and the branch is fetched
 and checked out with upstream tracking configured.
 
-For same-repo PRs, the branch is fetched and checked out.`,
+For same-repo PRs, the branch is fetched and checked out.
+
+The argument can be a PR number or a full URL:
+  forge pr checkout 123
+  forge pr checkout https://github.com/owner/repo/pull/123`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			number, err := strconv.Atoi(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid PR number: %s", args[0])
-			}
+			var (
+				forge           forges.Forge
+				owner, repoName string
+				domain          string
+				number          int
+				err             error
+			)
 
-			forge, owner, repoName, domain, err := resolve.Repo(flagRepo, flagForgeType)
-			if err != nil {
-				return err
+			// Try parsing as a number first
+			if n, parseErr := strconv.Atoi(args[0]); parseErr == nil {
+				number = n
+				forge, owner, repoName, domain, err = resolve.Repo(flagRepo, flagForgeType)
+				if err != nil {
+					return err
+				}
+			} else {
+				// Try parsing as a URL
+				var resourceType string
+				forge, owner, repoName, domain, resourceType, number, err = resolve.ResourceFromURL(args[0])
+				if err != nil {
+					return fmt.Errorf("invalid PR number or URL: %s", args[0])
+				}
+				if resourceType != "pr" {
+					return fmt.Errorf("URL does not point to a pull request: %s", args[0])
+				}
 			}
 
 			ctx := cmd.Context()

--- a/internal/cli/pr_checkout_test.go
+++ b/internal/cli/pr_checkout_test.go
@@ -96,7 +96,12 @@ func (m *mockForge) GetRateLimit(_ context.Context) (*forges.RateLimit, error) {
 }
 
 func (m *mockForge) ParsePath(_ []string) (*forges.ResourceRef, error) {
-	return &forges.ResourceRef{}, nil
+	return &forges.ResourceRef{
+		Owner:  "testowner",
+		Repo:   "testrepo",
+		Type:   forges.ResourceTypePR,
+		Number: 42,
+	}, nil
 }
 
 // setupTestRepo creates a temporary git repository with an initial commit
@@ -371,6 +376,19 @@ func TestPRCheckout(t *testing.T) {
 			args:        []string{"pr", "checkout", "42", "-b", "my-local-branch"},
 			setupOrigin: true,
 			wantBranch:  "my-local-branch",
+		},
+		{
+			name: "checkout by URL",
+			pr: &forges.PullRequest{
+				Number: 42,
+				Head: forges.PRBranch{
+					Ref: "feature-branch",
+					SHA: "abc123",
+				},
+			},
+			args:        []string{"pr", "checkout", "https://github.com/testowner/testrepo/pull/42"},
+			setupOrigin: true,
+			wantBranch:  "feature-branch",
 		},
 		{
 			name:    "invalid PR number",

--- a/internal/cli/pr_checkout_test.go
+++ b/internal/cli/pr_checkout_test.go
@@ -95,6 +95,10 @@ func (m *mockForge) GetRateLimit(_ context.Context) (*forges.RateLimit, error) {
 	return nil, forges.ErrNotSupported
 }
 
+func (m *mockForge) ParsePath(_ []string) (string, string, string, int, error) {
+	return "", "", "", 0, nil
+}
+
 // setupTestRepo creates a temporary git repository with an initial commit
 // and an origin remote pointing to a fake URL.
 func setupTestRepo(t *testing.T, originURL string) string {

--- a/internal/cli/pr_checkout_test.go
+++ b/internal/cli/pr_checkout_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/resolve"
 )
 

--- a/internal/cli/pr_checkout_test.go
+++ b/internal/cli/pr_checkout_test.go
@@ -95,8 +95,8 @@ func (m *mockForge) GetRateLimit(_ context.Context) (*forges.RateLimit, error) {
 	return nil, forges.ErrNotSupported
 }
 
-func (m *mockForge) ParsePath(_ []string) (string, string, string, int, error) {
-	return "", "", "", 0, nil
+func (m *mockForge) ParsePath(_ []string) (*forges.ResourceRef, error) {
+	return &forges.ResourceRef{}, nil
 }
 
 // setupTestRepo creates a temporary git repository with an initial commit

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/config"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 )
 
 func TestNotSupportedWrapsError(t *testing.T) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/output"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -139,16 +139,15 @@ func repoFromGitRemote(_ string) (forges.Forge, string, string, string, error) {
 }
 
 // ResourceFromURL resolves a forge and resource details from a full forge URL.
-// Returns the resource type ("pr" or "issue") and number if present in the URL.
-func ResourceFromURL(rawURL string) (forge forges.Forge, owner, repo, domain string, resourceType string, number int, err error) {
+func ResourceFromURL(rawURL string) (forge forges.Forge, domain string, ref *forges.ResourceRef, err error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, "", "", "", "", 0, fmt.Errorf("invalid URL: %w", err)
+		return nil, "", nil, fmt.Errorf("invalid URL: %w", err)
 	}
 	if u.Scheme == "" {
 		u, err = url.Parse("https://" + rawURL)
 		if err != nil {
-			return nil, "", "", "", "", 0, fmt.Errorf("invalid URL: %w", err)
+			return nil, "", nil, fmt.Errorf("invalid URL: %w", err)
 		}
 	}
 
@@ -162,17 +161,17 @@ func ResourceFromURL(rawURL string) (forge forges.Forge, owner, repo, domain str
 		client := newClient(domain)
 		f, err = forgeForDomainMaybeConfig(context.Background(), client, domain)
 		if err != nil {
-			return nil, "", "", "", "", 0, err
+			return nil, "", nil, err
 		}
 	}
 
 	parts := strings.Split(path, "/")
-	owner, repo, resourceType, number, err = f.ParsePath(parts)
+	ref, err = f.ParsePath(parts)
 	if err != nil {
-		return nil, "", "", "", "", 0, err
+		return nil, "", nil, err
 	}
 
-	return f, owner, repo, domain, resourceType, number, nil
+	return f, domain, ref, nil
 }
 
 func resolveRemote() (domain, owner, repo string, err error) {

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
-	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/bitbucket"
 	"github.com/git-pkgs/forge/gitea"
 	ghforge "github.com/git-pkgs/forge/github"
@@ -155,10 +155,15 @@ func ResourceFromURL(rawURL string) (forge forges.Forge, owner, repo, domain str
 	domain = u.Hostname()
 	path := strings.Trim(u.Path, "/")
 
-	client := newClient(domain)
-	f, err := forgeForDomainMaybeConfig(context.Background(), client, domain)
-	if err != nil {
-		return nil, "", "", "", "", 0, err
+	var f forges.Forge
+	if testForge != nil {
+		f = testForge
+	} else {
+		client := newClient(domain)
+		f, err = forgeForDomainMaybeConfig(context.Background(), client, domain)
+		if err != nil {
+			return nil, "", "", "", "", 0, err
+		}
 	}
 
 	parts := strings.Split(path, "/")

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
 
-	"github.com/git-pkgs/forge"
+	forges "github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/bitbucket"
 	"github.com/git-pkgs/forge/gitea"
 	ghforge "github.com/git-pkgs/forge/github"
@@ -135,6 +136,38 @@ func repoFromGitRemote(_ string) (forges.Forge, string, string, string, error) {
 		return nil, "", "", "", err
 	}
 	return f, owner, repo, domain, nil
+}
+
+// ResourceFromURL resolves a forge and resource details from a full forge URL.
+// Returns the resource type ("pr" or "issue") and number if present in the URL.
+func ResourceFromURL(rawURL string) (forge forges.Forge, owner, repo, domain string, resourceType string, number int, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, "", "", "", "", 0, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme == "" {
+		u, err = url.Parse("https://" + rawURL)
+		if err != nil {
+			return nil, "", "", "", "", 0, fmt.Errorf("invalid URL: %w", err)
+		}
+	}
+
+	domain = u.Hostname()
+	path := strings.Trim(u.Path, "/")
+
+	client := newClient(domain)
+	f, err := forgeForDomainMaybeConfig(context.Background(), client, domain)
+	if err != nil {
+		return nil, "", "", "", "", 0, err
+	}
+
+	parts := strings.Split(path, "/")
+	owner, repo, resourceType, number, err = f.ParsePath(parts)
+	if err != nil {
+		return nil, "", "", "", "", 0, err
+	}
+
+	return f, owner, repo, domain, resourceType, number, nil
 }
 
 func resolveRemote() (domain, owner, repo string, err error) {


### PR DESCRIPTION
Fix https://github.com/git-pkgs/forge/issues/102

forge has some helper functions that parse repo/owner from a URL, all within `detect.go` and `forge.go`. For example `splitOwnerRepo` just handles all URLs with zero levels of abstraction.

But I think this is the right architecture instead: Parse domain out of URL, and dispatch to the respective forge module. The cost is quite a bit of code duplication, but the logic can be tested separately.