### PR TITLE
Relax minimum Go version requirement  

### DIFF
--- a/gitea/prs.go
+++ b/gitea/prs.go
@@ -293,7 +293,7 @@ func (s *giteaPRService) Merge(ctx context.Context, owner, repo string, number i
 		gOpts.Style = gitea.MergeStyleMerge
 	}
 	if opts.Delete {
-		gOpts.DeleteBranchAfterMerge = gitea.OptionalBool(true)
+		gOpts.DeleteBranchAfterMerge = true
 	}
 
 	_, resp, err := s.client.MergePullRequest(owner, repo, int64(number), gOpts)

--- a/gitea/secrets.go
+++ b/gitea/secrets.go
@@ -54,7 +54,8 @@ func (s *giteaSecretService) List(ctx context.Context, owner, repo string, opts 
 }
 
 func (s *giteaSecretService) Set(ctx context.Context, owner, repo string, opts forge.SetSecretOpts) error {
-	resp, err := s.client.CreateRepoActionSecret(owner, repo, opts.Name, gitea.CreateOrUpdateSecretOption{
+	resp, err := s.client.CreateRepoActionSecret(owner, repo, gitea.CreateSecretOption{
+		Name: opts.Name,
 		Data: opts.Value,
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/git-pkgs/forge
 
-go 1.26
+go 1.25.6
 
 require (
-	code.gitea.io/sdk/gitea v0.25.1
+	code.gitea.io/sdk/gitea v0.23.2
 	github.com/git-pkgs/purl v0.1.12
 	github.com/google/go-github/v82 v82.0.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-code.gitea.io/sdk/gitea v0.25.1 h1:yywxWwoV+SdjHtbC6unBiXojWdZOtoHuGhEazEXeWuE=
-code.gitea.io/sdk/gitea v0.25.1/go.mod h1:uDFWYBU8dgZsgOHwe6C/6olxvf8FHguNB3wW1i83fgg=
+code.gitea.io/sdk/gitea v0.23.2 h1:iJB1FDmLegwfwjX8gotBDHdPSbk/ZR8V9VmEJaVsJYg=
+code.gitea.io/sdk/gitea v0.23.2/go.mod h1:yyF5+GhljqvA30sRDreoyHILruNiy4ASufugzYg0VHM=
 codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6MfY=
 codeberg.org/chavacava/garif v0.2.0/go.mod h1:P2BPbVbT4QcvLZrORc2T29szK3xEOlnl0GiPTJmEqBQ=
 codeberg.org/polyfloyd/go-errorlint v1.9.0 h1:VkdEEmA1VBpH6ecQoMR4LdphVI3fA4RrCh2an7YmodI=


### PR DESCRIPTION
closes #64 
##Summary                                                                                                                                                                       

 - lower Go version in go.mod to 1.25.6 to match dependency minimums                                                                                                          
 - pin Gitea SDK to v0.23.2 (last series requiring Go 1.23) to avoid forcing Go 1.26                                                                                          
 - update Gitea merge/secret calls for the older SDK API                                                                                                                      
                                                                                                                                                                              
##Testing                                                                                                                                                                       
                                                                                                                                                                              
 - go build -v ./...                                                                                                                                                          
 - go test -v -race ./...                                                                                                                                                     
 - go tool golangci-lint run ./... 