### PR TITLE
When viewing a pipeline, print the corresponding job ids

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -157,7 +157,7 @@ func ciViewCmd() *cobra.Command {
 					if j.Conclusion != "" {
 						jStatus = j.Conclusion
 					}
-					_, _ = fmt.Fprintf(os.Stdout, "  %s  %s\n", j.Name, jStatus)
+					_, _ = fmt.Fprintf(os.Stdout, "  %d  %s  %s\n", j.ID, j.Name, jStatus)
 				}
 			}
 


### PR DESCRIPTION
I was testing on a gitlab project and I wanted to see the log of a CI.

`forge ci list` first shows me a list of latest pipelines with their ids. `forge ci log` does not work directly on them, instead I need to `forge ci view` on the pipeline id, which makes sense.

But now I made `forge ci view` print the corresponding job ids, which I can then pass on to `forge ci log` and it works.