### PR TITLE
Add custom helptext when --json is used

### DIFF
--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -54,7 +54,7 @@ func prViewCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("json") {
-				return fmt.Errorf("--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view %s", strings.Join(args, " "))
+				return fmt.Errorf("--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>")
 			}
 
 			number, err := strconv.Atoi(args[0])

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -45,6 +45,7 @@ func prViewCmd() *cobra.Command {
 	var (
 		flagComments bool
 		flagWeb      bool
+		flagJSON     string
 	)
 
 	cmd := &cobra.Command{
@@ -52,6 +53,10 @@ func prViewCmd() *cobra.Command {
 		Short: "View a pull request",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("json") {
+				return fmt.Errorf("--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view %s", strings.Join(args, " "))
+			}
+
 			number, err := strconv.Atoi(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid PR number: %s", args[0])
@@ -96,6 +101,8 @@ func prViewCmd() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&flagComments, "comments", "c", false, "Show comments")
 	cmd.Flags().BoolVarP(&flagWeb, "web", "w", false, "Open in browser")
+	cmd.Flags().StringVar(&flagJSON, "json", "", "Not supported; use --output json")
+	_ = cmd.Flags().MarkHidden("json")
 	return cmd
 }
 

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -102,6 +102,7 @@ func prViewCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&flagComments, "comments", "c", false, "Show comments")
 	cmd.Flags().BoolVarP(&flagWeb, "web", "w", false, "Open in browser")
 	cmd.Flags().StringVar(&flagJSON, "json", "", "Not supported; use --output json")
+	cmd.Flags().Lookup("json").NoOptDefVal = " "
 	_ = cmd.Flags().MarkHidden("json")
 	return cmd
 }

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -54,7 +54,15 @@ func prViewCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("json") {
-				return fmt.Errorf("--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>")
+				var hints []string
+				hints = append(hints, "forge --output json pr view <number>")
+				if strings.Contains(flagJSON, "comments") {
+					hints = append(hints, "forge pr view --comments <number>")
+				}
+				if strings.Contains(flagJSON, "reviews") {
+					hints = append(hints, "forge pr review list <number>")
+				}
+				return fmt.Errorf("--json is not supported; use --output json instead (field selection is not supported)\n\nTry: %s", strings.Join(hints, "\n     "))
 			}
 
 			number, err := strconv.Atoi(args[0])

--- a/internal/cli/pr_test.go
+++ b/internal/cli/pr_test.go
@@ -144,17 +144,47 @@ func TestPRDiffRequiresArg(t *testing.T) {
 }
 
 func TestPRViewJSONFlagNotSupported(t *testing.T) {
-	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	rootCmd.SetErr(&buf)
-	rootCmd.SetArgs([]string{"pr", "view", "--json", "title"})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for --json flag")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "generic field",
+			args: []string{"pr", "view", "--json=title", "1"},
+			want: "--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>",
+		},
+		{
+			name: "comments field",
+			args: []string{"pr", "view", "--json=comments", "1"},
+			want: "--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>\n     forge pr view --comments <number>",
+		},
+		{
+			name: "reviews field",
+			args: []string{"pr", "view", "--json=reviews", "1"},
+			want: "--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>\n     forge pr review list <number>",
+		},
+		{
+			name: "both fields",
+			args: []string{"pr", "view", "--json=reviews,comments", "1"},
+			want: "--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>\n     forge pr view --comments <number>\n     forge pr review list <number>",
+		},
 	}
-	want := "--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>"
-	if err.Error() != want {
-		t.Errorf("unexpected error:\ngot:  %s\nwant: %s", err.Error(), want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			rootCmd.SetOut(&buf)
+			rootCmd.SetErr(&buf)
+			rootCmd.SetArgs(tt.args)
+
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for --json flag")
+			}
+			if err.Error() != tt.want {
+				t.Errorf("unexpected error:\ngot:  %s\nwant: %s", err.Error(), tt.want)
+			}
+		})
 	}
 }

--- a/internal/cli/pr_test.go
+++ b/internal/cli/pr_test.go
@@ -142,3 +142,19 @@ func TestPRDiffRequiresArg(t *testing.T) {
 		t.Fatal("expected error for missing argument")
 	}
 }
+
+func TestPRViewJSONFlagNotSupported(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"pr", "view", "--json", "title"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --json flag")
+	}
+	want := "--json is not supported; use --output json instead (field selection is not supported)\n\nTry: forge --output json pr view <number>"
+	if err.Error() != want {
+		t.Errorf("unexpected error:\ngot:  %s\nwant: %s", err.Error(), want)
+	}
+}


### PR DESCRIPTION
Fix https://github.com/git-pkgs/forge/issues/89

This doesn't actually implement any features (such as, selecting
specific JSON fields). All it does is steer the user to the right
option. The only reason I wanted this flag to begin with is so that
`alias gh=forge` becomes a better experience.
