### PR TITLE
Add FORGEJO_TOKEN environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ forge auth login --domain gitea.example.com --token abc123 --type gitea
 
 Check what's configured with `forge auth status`.
 
-Tokens are resolved in this order: CLI flags, environment variables (`FORGE_TOKEN`, `GITHUB_TOKEN`/`GH_TOKEN`, `GITLAB_TOKEN`, `GITEA_TOKEN`, `BITBUCKET_TOKEN`), then the config file at `~/.config/forge/config`. The target host is inferred from the current directory's git remote; use `--host` or `FORGE_HOST` to override it (for example `forge --host gitea.com repo list someone`).
+Tokens are resolved in this order: CLI flags, environment variables (`FORGE_TOKEN`, `GITHUB_TOKEN`/`GH_TOKEN`, `GITLAB_TOKEN`, `FORGEJO_TOKEN`/`GITEA_TOKEN`, `BITBUCKET_TOKEN`), then the config file at `~/.config/forge/config`. The target host is inferred from the current directory's git remote; use `--host` or `FORGE_HOST` to override it (for example `forge --host gitea.com repo list someone`).
 
 ### Configuration
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -313,6 +313,9 @@ func TokenForDomainEnv(domain string) string {
 			return t
 		}
 	case "codeberg.org":
+		if t := os.Getenv("FORGEJO_TOKEN"); t != "" {
+			return t
+		}
 		if t := os.Getenv("GITEA_TOKEN"); t != "" {
 			return t
 		}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -60,7 +60,7 @@ func clearTokenEnv(t *testing.T) {
 	for _, v := range []string{
 		"GITHUB_TOKEN", "GH_TOKEN",
 		"GITLAB_TOKEN", "GLAB_TOKEN",
-		"GITEA_TOKEN", "BITBUCKET_TOKEN",
+		"FORGEJO_TOKEN", "GITEA_TOKEN", "BITBUCKET_TOKEN",
 		"FORGE_TOKEN",
 	} {
 		t.Setenv(v, "")
@@ -106,6 +106,29 @@ func TestTokenForDomain(t *testing.T) {
 		t.Errorf("expected gl-tok, got %q", got)
 	}
 	t.Setenv("GITLAB_TOKEN", "")
+
+	// Codeberg (Forgejo / Gitea)
+	t.Setenv("GITEA_TOKEN", "gitea-tok")
+	got = TokenForDomain("codeberg.org")
+	if got != "gitea-tok" {
+		t.Errorf("expected gitea-tok, got %q", got)
+	}
+	t.Setenv("GITEA_TOKEN", "")
+
+	t.Setenv("FORGEJO_TOKEN", "forgejo-tok")
+	got = TokenForDomain("codeberg.org")
+	if got != "forgejo-tok" {
+		t.Errorf("expected forgejo-tok, got %q", got)
+	}
+
+	// FORGEJO_TOKEN should override GITEA_TOKEN
+	t.Setenv("GITEA_TOKEN", "gitea-tok")
+	got = TokenForDomain("codeberg.org")
+	if got != "forgejo-tok" {
+		t.Errorf("expected forgejo-tok to override gitea-tok, got %q", got)
+	}
+	t.Setenv("FORGEJO_TOKEN", "")
+	t.Setenv("GITEA_TOKEN", "")
 }
 
 func TestTokenForDomainEnvSpecificOverridesFallback(t *testing.T) {


### PR DESCRIPTION
This PR adds support for resolving token values via the `FORGEJO_TOKEN` environment variable for the `codeberg.org` domain, prioritizing it over `GITEA_TOKEN`.