### PR TITLE
command to retrieve token

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ forge auth login --domain github.com --token ghp_abc123
 forge auth login --domain gitea.example.com --token abc123 --type gitea
 ```
 
+When prompted for a token interactively, press **Ctrl+E** as the first key
+to enter a command instead. The command's output will be used as the token
+at runtime:
+
+```
+Token for github.com (Ctrl+E first for command): 
+Command for token (e.g. rbw get github.com): rbw get github-token
+```
+
 Check what's configured with `forge auth status`.
 
 Tokens are resolved in this order: CLI flags, environment variables (`FORGE_TOKEN`, `GITHUB_TOKEN`/`GH_TOKEN`, `GITLAB_TOKEN`, `FORGEJO_TOKEN`/`GITEA_TOKEN`, `BITBUCKET_TOKEN`), then the config file at `~/.config/forge/config`. The target host is inferred from the current directory's git remote; use `--host` or `FORGE_HOST` to override it (for example `forge --host gitea.com repo list someone`).
@@ -65,6 +74,25 @@ token = ghp_abc123
 type = gitea
 token = abc123
 ```
+
+Token values can be replaced with a shell command prefixed by `!`. The command
+is executed each time forge needs the token and its stdout is used as the value.
+This lets you fetch secrets from a password manager instead of storing them in
+plain text:
+
+```ini
+[github.com]
+token = !rbw get github-token
+
+[gitlab.com]
+token = !pass show forge/gitlab
+
+[myhostedgitlab.example.com]
+token = !rbw get --raw myhostedgitlab | jq -r '.fields | map(select(.name == "token"))[0].value'
+```
+
+`forge auth login` sets this up interactively (Ctrl+E at the token prompt).
+`forge auth status` shows the command source instead of the resolved value.
 
 `.forge` in the repo root is for per-project settings, committed to the repo, no tokens:
 

--- a/README.md
+++ b/README.md
@@ -80,20 +80,20 @@ token = abc123
 
 ### Token commands
 
-Token values can be replaced with a shell command prefixed by `!` (Unix only).
+Instead of a literal `token`, use `token-cmd` to specify a shell command (Unix only).
 The command is executed via `sh -c` each time forge needs the token and its
 stdout is used as the value. This lets you fetch secrets from a password manager
 instead of storing them in plain text:
 
 ```ini
 [github.com]
-token = !rbw get github-token
+token-cmd = rbw get github-token
 
 [gitlab.com]
-token = !pass show forge/gitlab
+token-cmd = pass show forge/gitlab
 
 [myhostedgitlab.example.com]
-token = !rbw get --raw myhostedgitlab | jq -r '.fields | map(select(.name == "token"))[0].value'
+token-cmd = rbw get --raw myhostedgitlab | jq -r '.fields | map(select(.name == "token"))[0].value'
 ```
 
 The variable `FORGE_DOMAIN` is set to the domain name when the command runs,
@@ -101,10 +101,10 @@ so a single command can serve multiple domains:
 
 ```ini
 [github.com]
-token = !pass show forge/$FORGE_DOMAIN
+token-cmd = pass show forge/$FORGE_DOMAIN
 
 [myhostedgitlab.example.com]
-token = !pass show forge/$FORGE_DOMAIN
+token-cmd = pass show forge/$FORGE_DOMAIN
 ```
 
 `forge auth login` sets this up interactively (Ctrl+E at the token prompt).

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ Store tokens with `forge auth login`:
 forge auth login                          # interactive: asks domain + token
 forge auth login --domain github.com --token ghp_abc123
 forge auth login --domain gitea.example.com --token abc123 --type gitea
+forge auth login --domain github.com --token-cmd 'rbw get github-token'
 ```
 
+`--token-cmd` stores a shell command instead of a literal token; the command
+is run each time the token is needed (see [token commands](#token-commands) below).
+
 When prompted for a token interactively, press **Ctrl+E** as the first key
-to enter a command instead. The command's output will be used as the token
-at runtime:
+to enter a command instead:
 
 ```
 Token for github.com (Ctrl+E first for command): 
@@ -74,6 +77,8 @@ token = ghp_abc123
 type = gitea
 token = abc123
 ```
+
+### Token commands
 
 Token values can be replaced with a shell command prefixed by `!` (Unix only).
 The command is executed via `sh -c` each time forge needs the token and its

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ token = !pass show forge/gitlab
 token = !rbw get --raw myhostedgitlab | jq -r '.fields | map(select(.name == "token"))[0].value'
 ```
 
+The variable `FORGE_DOMAIN` is set to the domain name when the command runs,
+so a single command can serve multiple domains:
+
+```ini
+[github.com]
+token = !pass show forge/$FORGE_DOMAIN
+
+[myhostedgitlab.example.com]
+token = !pass show forge/$FORGE_DOMAIN
+```
+
 `forge auth login` sets this up interactively (Ctrl+E at the token prompt).
 `forge auth status` shows the command source instead of the resolved value.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ token = abc123
 
 ### Token commands
 
-Instead of a literal `token`, use `token-cmd` to specify a shell command (Unix only).
+Instead of a literal `token`, use `token-cmd` to specify a shell command (not supported on Windows).
 The command is executed via `sh -c` each time forge needs the token and its
 stdout is used as the value. This lets you fetch secrets from a password manager
 instead of storing them in plain text:

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ type = gitea
 token = abc123
 ```
 
-Token values can be replaced with a shell command prefixed by `!`. The command
-is executed each time forge needs the token and its stdout is used as the value.
-This lets you fetch secrets from a password manager instead of storing them in
-plain text:
+Token values can be replaced with a shell command prefixed by `!` (Unix only).
+The command is executed via `sh -c` each time forge needs the token and its
+stdout is used as the value. This lets you fetch secrets from a password manager
+instead of storing them in plain text:
 
 ```ini
 [github.com]

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -54,26 +54,30 @@ func authLoginCmd() *cobra.Command {
 
 			switch {
 			case tokenCmd != "":
-				token = "!" + tokenCmd
+				// tokenCmd is already set from --token-cmd flag
 			case token == "":
 				if !interactive {
 					return fmt.Errorf("--token or --token-cmd is required in non-interactive mode")
 				}
 				var err error
-				token, err = readTokenInteractive(domain)
+				token, tokenCmd, err = readTokenInteractive(domain)
 				if err != nil {
 					return fmt.Errorf("reading token: %w", err)
 				}
-				if token == "" {
+				if token == "" && tokenCmd == "" {
 					return fmt.Errorf("token cannot be empty")
 				}
 			}
 
-			if err := config.SetDomain(domain, token, forgeType); err != nil {
+			if err := config.SetDomain(domain, token, tokenCmd, forgeType); err != nil {
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			_, _ = fmt.Fprintf(os.Stderr, "Stored credentials for %s\n", domain)
+			if tokenCmd != "" {
+				_, _ = fmt.Fprintf(os.Stderr, "Stored token command for %s\n", domain)
+			} else {
+				_, _ = fmt.Fprintf(os.Stderr, "Stored credentials for %s\n", domain)
+			}
 			return nil
 		},
 	}
@@ -87,8 +91,9 @@ func authLoginCmd() *cobra.Command {
 }
 
 // readTokenInteractive prompts for a token in raw mode.
-// Pressing Ctrl+E as the first key switches to command mode (stored as "!cmd").
-func readTokenInteractive(domain string) (string, error) {
+// Pressing Ctrl+E as the first key switches to command mode.
+// Exactly one of token or tokenCmd is non-empty on success.
+func readTokenInteractive(domain string) (token, tokenCmd string, err error) {
 	const ctrlE = 0x05
 
 	fd := int(os.Stdin.Fd())
@@ -96,24 +101,26 @@ func readTokenInteractive(domain string) (string, error) {
 
 	oldState, err := term.MakeRaw(fd)
 	if err != nil {
-		return "", fmt.Errorf("setting raw mode: %w", err)
+		return "", "", fmt.Errorf("setting raw mode: %w", err)
 	}
 
 	ch, err := readOneByte(os.Stdin)
 	if err != nil {
 		_ = term.Restore(fd, oldState)
 		_, _ = fmt.Fprintln(os.Stderr)
-		return "", err
+		return "", "", err
 	}
 
 	if ch == ctrlE {
 		_ = term.Restore(fd, oldState)
 		_, _ = fmt.Fprintln(os.Stderr)
-		return readCommandInteractive(domain)
+		cmd, err := readCommandInteractive(domain)
+		return "", cmd, err
 	}
 
 	r := io.MultiReader(bytes.NewReader([]byte{ch}), os.Stdin)
-	return readRawToken(fd, oldState, r)
+	tok, err := readRawToken(fd, oldState, r)
+	return tok, "", err
 }
 
 func readOneByte(r io.Reader) (byte, error) {
@@ -176,7 +183,6 @@ func readRawToken(fd int, oldState *term.State, r io.Reader) (string, error) {
 
 // readCommandInteractive prompts the user to enter a shell command
 // whose output will be used as the token at runtime.
-// Returns the command prefixed with "!" for storage in the config.
 func readCommandInteractive(domain string) (string, error) {
 	_, _ = fmt.Fprintf(os.Stderr, "Command for token (e.g. rbw get %s): ", domain)
 	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
@@ -187,7 +193,7 @@ func readCommandInteractive(domain string) (string, error) {
 	if cmd == "" {
 		return "", fmt.Errorf("command cannot be empty")
 	}
-	return "!" + cmd, nil
+	return cmd, nil
 }
 
 func authStatusCmd() *cobra.Command {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -85,8 +85,6 @@ func authLoginCmd() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("token", "token-cmd")
 	return cmd
 }
-	return cmd
-}
 
 // readTokenInteractive prompts for a token in raw mode.
 // Pressing Ctrl+E as the first key switches to command mode (stored as "!cmd").

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -23,12 +23,14 @@ func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(authLoginCmd())
 	authCmd.AddCommand(authStatusCmd())
+	authCmd.AddCommand(authTokenCmd())
 }
 
 func authLoginCmd() *cobra.Command {
 	var (
 		domain    string
 		token     string
+		tokenCmd  string
 		forgeType string
 	)
 
@@ -51,9 +53,12 @@ func authLoginCmd() *cobra.Command {
 				}
 			}
 
-			if token == "" {
+			switch {
+			case tokenCmd != "":
+				token = "!" + tokenCmd
+			case token == "":
 				if !interactive {
-					return fmt.Errorf("--token is required in non-interactive mode")
+					return fmt.Errorf("--token or --token-cmd is required in non-interactive mode")
 				}
 				var err error
 				token, err = readTokenInteractive(domain)
@@ -76,7 +81,11 @@ func authLoginCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&domain, "domain", "", "Forge domain (e.g. github.com, gitea.example.com)")
 	cmd.Flags().StringVar(&token, "token", "", "API token")
+	cmd.Flags().StringVar(&tokenCmd, "token-cmd", "", "Shell command whose stdout is used as the token (Unix only)")
 	cmd.Flags().StringVar(&forgeType, "type", "", "Forge type: github, gitlab, gitea, forgejo, bitbucket")
+	cmd.MarkFlagsMutuallyExclusive("token", "token-cmd")
+	return cmd
+}
 	return cmd
 }
 
@@ -124,6 +133,7 @@ func readRawToken(fd int, oldState *term.State, r io.Reader) (string, error) {
 		ctrlD     = 0x04
 		enter     = 0x0D
 		newline   = 0x0A
+		esc       = 0x1B
 		backspace = 0x7F
 		del       = 0x08
 		printable = 0x20
@@ -148,6 +158,16 @@ func readRawToken(fd int, oldState *term.State, r io.Reader) (string, error) {
 		case backspace, del:
 			if len(buf) > 0 {
 				buf = buf[:len(buf)-1]
+			}
+		case esc:
+			// Consume the rest of the escape sequence (e.g. arrow keys: \x1b[D).
+			for {
+				if _, err := r.Read(b); err != nil {
+					return "", err
+				}
+				if b[0] >= 'A' && b[0] <= '~' {
+					break
+				}
 			}
 		default:
 			if b[0] >= printable {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
@@ -53,13 +56,11 @@ func authLoginCmd() *cobra.Command {
 				if !interactive {
 					return fmt.Errorf("--token is required in non-interactive mode")
 				}
-				_, _ = fmt.Fprintf(os.Stderr, "Token for %s: ", domain)
-				raw, err := term.ReadPassword(int(os.Stdin.Fd()))
-				_, _ = fmt.Fprintln(os.Stderr) // newline after hidden input
+				var err error
+				token, err = readTokenInteractive(domain)
 				if err != nil {
 					return fmt.Errorf("reading token: %w", err)
 				}
-				token = strings.TrimSpace(string(raw))
 				if token == "" {
 					return fmt.Errorf("token cannot be empty")
 				}
@@ -78,6 +79,96 @@ func authLoginCmd() *cobra.Command {
 	cmd.Flags().StringVar(&token, "token", "", "API token")
 	cmd.Flags().StringVar(&forgeType, "type", "", "Forge type: github, gitlab, gitea, forgejo, bitbucket")
 	return cmd
+}
+
+// readTokenInteractive prompts for a token in raw mode.
+// Pressing Ctrl+E as the first key switches to command mode (stored as "!cmd").
+func readTokenInteractive(domain string) (string, error) {
+	const ctrlE = 0x05
+
+	fd := int(os.Stdin.Fd())
+	_, _ = fmt.Fprintf(os.Stderr, "Token for %s (Ctrl+E first for command): ", domain)
+
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return "", fmt.Errorf("setting raw mode: %w", err)
+	}
+
+	ch, err := readOneByte(os.Stdin)
+	if err != nil {
+		_ = term.Restore(fd, oldState)
+		_, _ = fmt.Fprintln(os.Stderr)
+		return "", err
+	}
+
+	if ch == ctrlE {
+		_ = term.Restore(fd, oldState)
+		_, _ = fmt.Fprintln(os.Stderr)
+		return readCommandInteractive(domain)
+	}
+
+	r := io.MultiReader(bytes.NewReader([]byte{ch}), os.Stdin)
+	return readRawToken(fd, oldState, r)
+}
+
+func readOneByte(r io.Reader) (byte, error) {
+	b := make([]byte, 1)
+	_, err := r.Read(b)
+	return b[0], err
+}
+
+// readRawToken accumulates a token character by character in raw mode.
+// Always restores the terminal before returning.
+func readRawToken(fd int, oldState *term.State, r io.Reader) (string, error) {
+	const (
+		ctrlC     = 0x03
+		ctrlD     = 0x04
+		enter     = 0x0D
+		newline   = 0x0A
+		backspace = 0x7F
+		del       = 0x08
+		printable = 0x20
+	)
+	defer func() {
+		_ = term.Restore(fd, oldState)
+		_, _ = fmt.Fprintln(os.Stderr)
+	}()
+
+	var buf []byte
+	b := make([]byte, 1)
+	for {
+		if _, err := r.Read(b); err != nil {
+			return "", err
+		}
+
+		switch b[0] {
+		case ctrlC, ctrlD:
+			return "", fmt.Errorf("interrupted")
+		case enter, newline:
+			return strings.TrimSpace(string(buf)), nil
+		case backspace, del:
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+			}
+		default:
+			if b[0] >= printable {
+				buf = append(buf, b[0])
+			}
+		}
+	}
+}
+
+// readCommandInteractive prompts the user to enter a shell command
+// whose output will be used as the token at runtime.
+// Returns the command prefixed with "!" for storage in the config.
+func readCommandInteractive(domain string) (string, error) {
+	_, _ = fmt.Fprintf(os.Stderr, "Command for token (e.g. rbw get %s): ", domain)
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	cmd := strings.TrimSpace(line)
+	if cmd == "" {
+		return "", fmt.Errorf("command cannot be empty")
+	}
+	return "!" + cmd, nil
 }
 
 func authStatusCmd() *cobra.Command {
@@ -111,7 +202,11 @@ func authStatusCmd() *cobra.Command {
 					sources = append(sources, "env")
 				}
 				if cfgSection.Token != "" {
-					sources = append(sources, "config")
+					if cfgSection.TokenExec != "" {
+						sources = append(sources, fmt.Sprintf("config (cmd: %s)", cfgSection.TokenExec))
+					} else {
+						sources = append(sources, "config")
+					}
 				}
 
 				status := "no token"
@@ -121,9 +216,9 @@ func authStatusCmd() *cobra.Command {
 
 				forgeType := cfgSection.Type
 				if forgeType != "" {
-					_, _ = fmt.Fprintf(os.Stdout, "%s (%s): %s\n", d, forgeType, status)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s (%s): %s\n", d, forgeType, status)
 				} else {
-					_, _ = fmt.Fprintf(os.Stdout, "%s: %s\n", d, status)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", d, status)
 				}
 			}
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -162,7 +162,10 @@ func readRawToken(fd int, oldState *term.State, r io.Reader) (string, error) {
 // Returns the command prefixed with "!" for storage in the config.
 func readCommandInteractive(domain string) (string, error) {
 	_, _ = fmt.Fprintf(os.Stderr, "Command for token (e.g. rbw get %s): ", domain)
-	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && line == "" {
+		return "", fmt.Errorf("reading command: %w", err)
+	}
 	cmd := strings.TrimSpace(line)
 	if cmd == "" {
 		return "", fmt.Errorf("command cannot be empty")

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -169,7 +169,7 @@ func readRawToken(fd int, oldState *term.State, r io.Reader) (string, error) {
 				if _, err := r.Read(b); err != nil {
 					return "", err
 				}
-				if b[0] >= 'A' && b[0] <= '~' {
+				if b[0] >= '@' && b[0] <= '~' {
 					break
 				}
 			}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -23,7 +23,6 @@ func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(authLoginCmd())
 	authCmd.AddCommand(authStatusCmd())
-	authCmd.AddCommand(authTokenCmd())
 }
 
 func authLoginCmd() *cobra.Command {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/term"
 )
 
-
 var authCmd = &cobra.Command{
 	Use:   "auth",
 	Short: "Manage authentication",

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -200,12 +200,10 @@ func authStatusCmd() *cobra.Command {
 				if envToken != "" {
 					sources = append(sources, "env")
 				}
-				if cfgSection.Token != "" {
-					if cfgSection.TokenExec != "" {
-						sources = append(sources, fmt.Sprintf("config (cmd: %s)", cfgSection.TokenExec))
-					} else {
-						sources = append(sources, "config")
-					}
+				if cfgSection.TokenExec != "" {
+					sources = append(sources, fmt.Sprintf("config (cmd: %s)", cfgSection.TokenExec))
+				} else if cfgSection.Token != "" {
+					sources = append(sources, "config")
 				}
 
 				status := "no token"

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -138,7 +138,7 @@ func TestAuthLoginTokenCmd(t *testing.T) {
 		t.Fatalf("reading config: %v", err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "token = !rbw get github-token") {
+	if !strings.Contains(content, "token-cmd = rbw get github-token") {
 		t.Errorf("expected token command in config, got:\n%s", content)
 	}
 }
@@ -203,7 +203,7 @@ func TestAuthStatusWithTokenCmd(t *testing.T) {
 	_ = os.MkdirAll(cfgDir, 0700)
 	_ = os.WriteFile(filepath.Join(cfgDir, "config"), []byte(`[gitlab.example.com]
 type = gitlab
-token = !echo secret
+token-cmd = echo secret
 `), 0600)
 
 	var buf bytes.Buffer
@@ -247,8 +247,8 @@ func TestReadCommandInteractive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != "!rbw get github-token" {
-		t.Errorf("expected %q, got %q", "!rbw get github-token", result)
+	if result != "rbw get github-token" {
+		t.Errorf("expected %q, got %q", "rbw get github-token", result)
 	}
 }
 

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -95,6 +95,51 @@ func TestAuthLoginNonInteractive(t *testing.T) {
 	}
 }
 
+func TestAuthLoginTokenCmd(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	config.ResetCache()
+	defer config.ResetCache()
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{
+		"auth", "login",
+		"--domain", "github.com",
+		"--token-cmd", "rbw get github-token",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "forge", "config"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "token = !rbw get github-token") {
+		t.Errorf("expected token command in config, got:\n%s", content)
+	}
+}
+
+func TestAuthLoginTokenAndTokenCmdMutuallyExclusive(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{
+		"auth", "login",
+		"--domain", "github.com",
+		"--token", "ghp_abc",
+		"--token-cmd", "rbw get github-token",
+	})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when both --token and --token-cmd are set")
+	}
+}
+
 func TestAuthStatus(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -101,7 +101,6 @@ func TestAuthStatus(t *testing.T) {
 	config.ResetCache()
 	defer config.ResetCache()
 
-	// Write a config with a domain
 	cfgDir := filepath.Join(dir, "forge")
 	_ = os.MkdirAll(cfgDir, 0700)
 	_ = os.WriteFile(filepath.Join(cfgDir, "config"), []byte(`[gitea.example.com]
@@ -114,8 +113,95 @@ token = some_token
 	rootCmd.SetErr(&buf)
 	rootCmd.SetArgs([]string{"auth", "status"})
 
-	err := rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "gitea.example.com") {
+		t.Errorf("expected domain in output, got: %s", out)
+	}
+	if !strings.Contains(out, "token from config") {
+		t.Errorf("expected token source in output, got: %s", out)
+	}
+}
+
+func TestAuthStatusWithTokenCmd(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	config.ResetCache()
+	defer config.ResetCache()
+
+	cfgDir := filepath.Join(dir, "forge")
+	_ = os.MkdirAll(cfgDir, 0700)
+	_ = os.WriteFile(filepath.Join(cfgDir, "config"), []byte(`[gitlab.example.com]
+type = gitlab
+token = !echo secret
+`), 0600)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"auth", "status"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "cmd: !echo secret") {
+		t.Errorf("expected command source in output, got: %s", out)
+	}
+}
+
+func TestReadOneByte(t *testing.T) {
+	b, err := readOneByte(bytes.NewReader([]byte{'x'}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if b != 'x' {
+		t.Errorf("expected 'x', got %q", b)
+	}
+}
+
+func TestReadCommandInteractive(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin; _ = r.Close() }()
+
+	_, _ = w.WriteString("rbw get github-token\n")
+	_ = w.Close()
+
+	result, err := readCommandInteractive("github.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "!rbw get github-token" {
+		t.Errorf("expected %q, got %q", "!rbw get github-token", result)
+	}
+}
+
+func TestReadCommandInteractiveEmpty(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin; _ = r.Close() }()
+
+	_, _ = w.WriteString("\n")
+	_ = w.Close()
+
+	_, err = readCommandInteractive("github.com")
+	if err == nil {
+		t.Fatal("expected error for empty command")
+	}
+	if !strings.Contains(err.Error(), "cannot be empty") {
+		t.Errorf("expected empty command error, got: %v", err)
 	}
 }

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -149,7 +149,7 @@ token = !echo secret
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "cmd: !echo secret") {
+	if !strings.Contains(out, "cmd: echo secret") {
 		t.Errorf("expected command source in output, got: %s", out)
 	}
 }

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -8,7 +8,23 @@ import (
 	"testing"
 
 	"github.com/git-pkgs/forge/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// resetCmd resets flag values and Changed state across the command tree so
+// tests using the shared rootCmd don't leak flag state into each other.
+func resetCmd(cmd *cobra.Command) {
+	reset := func(f *pflag.Flag) {
+		f.Changed = false
+		_ = f.Value.Set(f.DefValue)
+	}
+	cmd.Flags().VisitAll(reset)
+	cmd.PersistentFlags().VisitAll(reset)
+	for _, sub := range cmd.Commands() {
+		resetCmd(sub)
+	}
+}
 
 func TestAuthCmd(t *testing.T) {
 	cmd := authCmd
@@ -36,6 +52,7 @@ func TestAuthCmd(t *testing.T) {
 }
 
 func TestAuthLoginRequiresDomainNonInteractive(t *testing.T) {
+	resetCmd(rootCmd)
 	// Replace stdin with a pipe so term.IsTerminal returns false
 	origStdin := os.Stdin
 	r, w, _ := os.Pipe()
@@ -58,6 +75,7 @@ func TestAuthLoginRequiresDomainNonInteractive(t *testing.T) {
 }
 
 func TestAuthLoginNonInteractive(t *testing.T) {
+	resetCmd(rootCmd)
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	config.ResetCache()
@@ -96,6 +114,7 @@ func TestAuthLoginNonInteractive(t *testing.T) {
 }
 
 func TestAuthLoginTokenCmd(t *testing.T) {
+	resetCmd(rootCmd)
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	config.ResetCache()
@@ -125,6 +144,7 @@ func TestAuthLoginTokenCmd(t *testing.T) {
 }
 
 func TestAuthLoginTokenAndTokenCmdMutuallyExclusive(t *testing.T) {
+	resetCmd(rootCmd)
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
@@ -141,6 +161,7 @@ func TestAuthLoginTokenAndTokenCmdMutuallyExclusive(t *testing.T) {
 }
 
 func TestAuthStatus(t *testing.T) {
+	resetCmd(rootCmd)
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	config.ResetCache()
@@ -172,6 +193,7 @@ token = some_token
 }
 
 func TestAuthStatusWithTokenCmd(t *testing.T) {
+	resetCmd(rootCmd)
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	config.ResetCache()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ type DefaultSection struct {
 type DomainSection struct {
 	Type        string // github, gitlab, gitea, forgejo, bitbucket
 	Token       string // resolved token value; only from user config, never .forge
-	TokenExec   string // non-empty when token came from a "!cmd" reference (stores the raw value)
+	TokenExec   string // non-empty when token is retrieved via a shell command (from "token-cmd" config key)
 	SSHHost     string // alternate host for git-over-ssh; the section name remains the API host
 	GitProtocol string // https or ssh; overrides default
 }
@@ -208,12 +208,16 @@ func loadFile(cfg *Config, path string, allowTokens bool) error {
 			}
 		}
 		if allowTokens {
-			if v, ok := kv["token"]; ok {
-				if strings.HasPrefix(v, "!") {
-					ds.TokenExec = v[1:]
-				} else {
-					ds.Token = v
-				}
+			_, hasToken := kv["token"]
+			_, hasTokenCmd := kv["token-cmd"]
+			if hasToken && hasTokenCmd {
+				return fmt.Errorf("%s: [%s] token and token-cmd are mutually exclusive", path, name)
+			}
+			if hasToken {
+				ds.Token = kv["token"]
+			}
+			if hasTokenCmd {
+				ds.TokenExec = kv["token-cmd"]
 			}
 		}
 		cfg.Domains[name] = ds
@@ -303,7 +307,7 @@ func findProjectConfig(dir string) string {
 // SetDomain updates or adds a domain section in the user config file.
 // Creates the config directory if needed. Sets file permissions to 0600
 // since the file may contain tokens.
-func SetDomain(domain, token, forgeType string) error {
+func SetDomain(domain, token, tokenCmd, forgeType string) error {
 	path := UserConfigPath()
 	if path == "" {
 		return fmt.Errorf("cannot determine config path")
@@ -328,6 +332,11 @@ func SetDomain(domain, token, forgeType string) error {
 	}
 	if token != "" {
 		sections[domain]["token"] = token
+		delete(sections[domain], "token-cmd")
+	}
+	if tokenCmd != "" {
+		sections[domain]["token-cmd"] = tokenCmd
+		delete(sections[domain], "token")
 	}
 	if forgeType != "" {
 		sections[domain]["type"] = forgeType

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,12 +98,15 @@ func parseGitProtocol(v string) (string, error) {
 
 // execValue runs cmd via sh -c and returns its trimmed stdout.
 // Shell features (pipes, quotes, substitutions) are supported.
-func execValue(cmd string) (string, error) {
+// FORGE_DOMAIN is set to domain in the command environment.
+func execValue(cmd, domain string) (string, error) {
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return "", fmt.Errorf("empty command")
 	}
-	out, err := exec.Command("sh", "-c", cmd).Output()
+	c := exec.Command("sh", "-c", cmd)
+	c.Env = append(os.Environ(), "FORGE_DOMAIN="+domain)
+	out, err := c.Output()
 	if err != nil {
 		return "", fmt.Errorf("%q: %w", cmd, err)
 	}
@@ -193,7 +196,7 @@ func loadFile(cfg *Config, path string, allowTokens bool) error {
 		if allowTokens {
 			if v, ok := kv["token"]; ok {
 				if strings.HasPrefix(v, "!") {
-					resolved, err := execValue(v[1:])
+					resolved, err := execValue(v[1:], name)
 					if err != nil {
 						return fmt.Errorf("%s: [%s] token command: %w", path, name, err)
 					}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -30,7 +31,8 @@ type DefaultSection struct {
 
 type DomainSection struct {
 	Type        string // github, gitlab, gitea, forgejo, bitbucket
-	Token       string // only from user config, never .forge
+	Token       string // resolved token value; only from user config, never .forge
+	TokenExec   string // non-empty when token came from a "!cmd" reference (stores the raw value)
 	SSHHost     string // alternate host for git-over-ssh; the section name remains the API host
 	GitProtocol string // https or ssh; overrides default
 }
@@ -92,6 +94,20 @@ func parseGitProtocol(v string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid git_protocol %q: must be \"https\" or \"ssh\"", v)
 	}
+}
+
+// execValue runs cmd via sh -c and returns its trimmed stdout.
+// Shell features (pipes, quotes, substitutions) are supported.
+func execValue(cmd string) (string, error) {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return "", fmt.Errorf("empty command")
+	}
+	out, err := exec.Command("sh", "-c", cmd).Output()
+	if err != nil {
+		return "", fmt.Errorf("%q: %w", cmd, err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // ResetCache clears the cached config. Only useful in tests.
@@ -176,7 +192,16 @@ func loadFile(cfg *Config, path string, allowTokens bool) error {
 		}
 		if allowTokens {
 			if v, ok := kv["token"]; ok {
-				ds.Token = v
+				if strings.HasPrefix(v, "!") {
+					resolved, err := execValue(v[1:])
+					if err != nil {
+						return fmt.Errorf("%s: [%s] token command: %w", path, name, err)
+					}
+					ds.Token = resolved
+					ds.TokenExec = v
+				} else {
+					ds.Token = v
+				}
 			}
 		}
 		cfg.Domains[name] = ds

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ type DomainSection struct {
 // executes the command and returns its output; otherwise it returns Token.
 func (ds DomainSection) ResolveToken(domain string) (string, error) {
 	if ds.TokenExec != "" {
-		return execValue(ds.TokenExec[1:], domain)
+		return execValue(ds.TokenExec, domain)
 	}
 	return ds.Token, nil
 }
@@ -210,7 +210,7 @@ func loadFile(cfg *Config, path string, allowTokens bool) error {
 		if allowTokens {
 			if v, ok := kv["token"]; ok {
 				if strings.HasPrefix(v, "!") {
-					ds.TokenExec = v
+					ds.TokenExec = v[1:]
 				} else {
 					ds.Token = v
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,15 @@ type DomainSection struct {
 	GitProtocol string // https or ssh; overrides default
 }
 
+// ResolveToken returns the token for this domain. If TokenExec is set, it
+// executes the command and returns its output; otherwise it returns Token.
+func (ds DomainSection) ResolveToken(domain string) (string, error) {
+	if ds.TokenExec != "" {
+		return execValue(ds.TokenExec[1:], domain)
+	}
+	return ds.Token, nil
+}
+
 // DomainForSSHHost returns the API domain (the section name) whose ssh_host
 // matches the given host, or "" if none. Self-hosted GitLab in particular can
 // serve git-over-ssh on a different host than the web/API, so a remote URL like
@@ -99,18 +108,23 @@ func parseGitProtocol(v string) (string, error) {
 // execValue runs cmd via sh -c and returns its trimmed stdout.
 // Shell features (pipes, quotes, substitutions) are supported.
 // FORGE_DOMAIN is set to domain in the command environment.
+// Stdin and stderr are wired to the terminal so interactive prompts
+// (e.g. pinentry, rbw unlock) work and error output is visible directly.
 func execValue(cmd, domain string) (string, error) {
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return "", fmt.Errorf("empty command")
 	}
+	var stdout strings.Builder
 	c := exec.Command("sh", "-c", cmd)
 	c.Env = append(os.Environ(), "FORGE_DOMAIN="+domain)
-	out, err := c.Output()
-	if err != nil {
+	c.Stdin = os.Stdin
+	c.Stdout = &stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
 		return "", fmt.Errorf("%q: %w", cmd, err)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 // ResetCache clears the cached config. Only useful in tests.
@@ -196,11 +210,6 @@ func loadFile(cfg *Config, path string, allowTokens bool) error {
 		if allowTokens {
 			if v, ok := kv["token"]; ok {
 				if strings.HasPrefix(v, "!") {
-					resolved, err := execValue(v[1:], name)
-					if err != nil {
-						return fmt.Errorf("%s: [%s] token command: %w", path, name, err)
-					}
-					ds.Token = resolved
 					ds.TokenExec = v
 				} else {
 					ds.Token = v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,9 @@ func parseGitProtocol(v string) (string, error) {
 // Stdin and stderr are wired to the terminal so interactive prompts
 // (e.g. pinentry, rbw unlock) work and error output is visible directly.
 func execValue(cmd, domain string) (string, error) {
+	if runtime.GOOS == goosWindows {
+		return "", fmt.Errorf("token-cmd is not supported on Windows")
+	}
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return "", fmt.Errorf("empty command")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -504,6 +504,24 @@ token = !echo mytoken
 	}
 }
 
+func TestLoadFileTokenCommandForgeDomain(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[gitlab.example.com]
+token = !echo $FORGE_DOMAIN
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	if err := loadFile(cfg, path, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ds := cfg.Domains["gitlab.example.com"]
+	if ds.Token != "gitlab.example.com" {
+		t.Errorf("expected FORGE_DOMAIN=gitlab.example.com, got %q", ds.Token)
+	}
+}
+
 func TestLoadFileTokenCommandFails(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -483,6 +483,101 @@ token = old_token
 	}
 }
 
+func TestLoadFileTokenCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[github.com]
+token = !echo mytoken
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	if err := loadFile(cfg, path, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ds := cfg.Domains["github.com"]
+	if ds.Token != "mytoken" {
+		t.Errorf("expected resolved token %q, got %q", "mytoken", ds.Token)
+	}
+	if ds.TokenExec != "!echo mytoken" {
+		t.Errorf("expected TokenExec=%q, got %q", "!echo mytoken", ds.TokenExec)
+	}
+}
+
+func TestLoadFileTokenCommandFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[github.com]
+token = !false
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	err := loadFile(cfg, path, true)
+	if err == nil {
+		t.Fatal("expected error from failing command, got nil")
+	}
+	if !strings.Contains(err.Error(), "token command") {
+		t.Errorf("expected error to mention token command, got: %v", err)
+	}
+}
+
+func TestLoadFileTokenCommandMissingBinary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[github.com]
+token = !no-such-binary-xyz
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	err := loadFile(cfg, path, true)
+	if err == nil {
+		t.Fatal("expected error for missing binary, got nil")
+	}
+}
+
+func TestLoadFileTokenCommandNotExecutedInProjectConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".forge")
+	_ = os.WriteFile(path, []byte(`[github.com]
+token = !echo secret
+`), 0644)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	// allowTokens=false: command must not be executed, token must stay empty
+	if err := loadFile(cfg, path, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ds := cfg.Domains["github.com"]
+	if ds.Token != "" {
+		t.Errorf("project config should not resolve token commands, got %q", ds.Token)
+	}
+	if ds.TokenExec != "" {
+		t.Errorf("project config should not set TokenExec, got %q", ds.TokenExec)
+	}
+}
+
+func TestLoadFileLiteralTokenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[github.com]
+token = ghp_literal
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	if err := loadFile(cfg, path, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ds := cfg.Domains["github.com"]
+	if ds.Token != "ghp_literal" {
+		t.Errorf("expected literal token, got %q", ds.Token)
+	}
+	if ds.TokenExec != "" {
+		t.Errorf("expected empty TokenExec for literal token, got %q", ds.TokenExec)
+	}
+}
+
 func TestGitProtocolFor(t *testing.T) {
 	ResetCache()
 	defer ResetCache()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -350,7 +350,7 @@ func TestSetDomain(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	err := SetDomain("gitea.example.com", "tok123", "gitea")
+	err := SetDomain("gitea.example.com", "tok123", "", "gitea")
 	if err != nil {
 		t.Fatalf("SetDomain: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestSetDomainTightensExistingPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SetDomain("github.com", "ghp_secret", ""); err != nil {
+	if err := SetDomain("github.com", "ghp_secret", "", ""); err != nil {
 		t.Fatalf("SetDomain: %v", err)
 	}
 
@@ -434,7 +434,7 @@ type = gitlab
 `), 0600)
 
 	// Add a new domain; existing entries should survive.
-	err := SetDomain("codeberg.org", "tok_new", "gitea")
+	err := SetDomain("codeberg.org", "tok_new", "", "gitea")
 	if err != nil {
 		t.Fatalf("SetDomain: %v", err)
 	}
@@ -468,7 +468,7 @@ token = old_token
 `), 0600)
 
 	// Update
-	err := SetDomain("github.com", "new_token", "")
+	err := SetDomain("github.com", "new_token", "", "")
 	if err != nil {
 		t.Fatalf("SetDomain: %v", err)
 	}
@@ -487,7 +487,7 @@ func TestLoadFileTokenCommand(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	_ = os.WriteFile(path, []byte(`[github.com]
-token = !echo mytoken
+token-cmd = echo mytoken
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
@@ -512,11 +512,29 @@ token = !echo mytoken
 	}
 }
 
+func TestLoadFileTokenAndTokenCmdMutuallyExclusive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_ = os.WriteFile(path, []byte(`[github.com]
+token = ghp_abc
+token-cmd = rbw get github-token
+`), 0600)
+
+	cfg := &Config{Domains: make(map[string]DomainSection)}
+	err := loadFile(cfg, path, true)
+	if err == nil {
+		t.Fatal("expected error when both token and token-cmd are set, got nil")
+	}
+	if !strings.Contains(err.Error(), "token") || !strings.Contains(err.Error(), "token-cmd") {
+		t.Errorf("expected error to mention both keys, got: %v", err)
+	}
+}
+
 func TestLoadFileTokenCommandForgeDomain(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	_ = os.WriteFile(path, []byte(`[gitlab.example.com]
-token = !echo $FORGE_DOMAIN
+token-cmd = echo $FORGE_DOMAIN
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
@@ -537,7 +555,7 @@ func TestLoadFileTokenCommandFails(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	_ = os.WriteFile(path, []byte(`[github.com]
-token = !false
+token-cmd = false
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
@@ -555,7 +573,7 @@ func TestLoadFileTokenCommandMissingBinary(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	_ = os.WriteFile(path, []byte(`[github.com]
-token = !no-such-binary-xyz
+token-cmd = no-such-binary-xyz
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
@@ -573,7 +591,7 @@ func TestLoadFileTokenCommandNotExecutedInProjectConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".forge")
 	_ = os.WriteFile(path, []byte(`[github.com]
-token = !echo secret
+token-cmd = echo secret
 `), 0644)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -496,11 +496,19 @@ token = !echo mytoken
 	}
 
 	ds := cfg.Domains["github.com"]
-	if ds.Token != "mytoken" {
-		t.Errorf("expected resolved token %q, got %q", "mytoken", ds.Token)
+	if ds.Token != "" {
+		t.Errorf("loadFile should not resolve token command, got Token=%q", ds.Token)
 	}
 	if ds.TokenExec != "!echo mytoken" {
 		t.Errorf("expected TokenExec=%q, got %q", "!echo mytoken", ds.TokenExec)
+	}
+
+	resolved, err := ds.ResolveToken("github.com")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	if resolved != "mytoken" {
+		t.Errorf("expected resolved token %q, got %q", "mytoken", resolved)
 	}
 }
 
@@ -516,9 +524,12 @@ token = !echo $FORGE_DOMAIN
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ds := cfg.Domains["gitlab.example.com"]
-	if ds.Token != "gitlab.example.com" {
-		t.Errorf("expected FORGE_DOMAIN=gitlab.example.com, got %q", ds.Token)
+	resolved, err := cfg.Domains["gitlab.example.com"].ResolveToken("gitlab.example.com")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	if resolved != "gitlab.example.com" {
+		t.Errorf("expected FORGE_DOMAIN=gitlab.example.com, got %q", resolved)
 	}
 }
 
@@ -530,12 +541,13 @@ token = !false
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
-	err := loadFile(cfg, path, true)
+	if err := loadFile(cfg, path, true); err != nil {
+		t.Fatalf("loadFile should not fail on bad command, got: %v", err)
+	}
+
+	_, err := cfg.Domains["github.com"].ResolveToken("github.com")
 	if err == nil {
 		t.Fatal("expected error from failing command, got nil")
-	}
-	if !strings.Contains(err.Error(), "token command") {
-		t.Errorf("expected error to mention token command, got: %v", err)
 	}
 }
 
@@ -547,7 +559,11 @@ token = !no-such-binary-xyz
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
-	err := loadFile(cfg, path, true)
+	if err := loadFile(cfg, path, true); err != nil {
+		t.Fatalf("loadFile should not fail on missing binary, got: %v", err)
+	}
+
+	_, err := cfg.Domains["github.com"].ResolveToken("github.com")
 	if err == nil {
 		t.Fatal("expected error for missing binary, got nil")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -499,8 +499,8 @@ token = !echo mytoken
 	if ds.Token != "" {
 		t.Errorf("loadFile should not resolve token command, got Token=%q", ds.Token)
 	}
-	if ds.TokenExec != "!echo mytoken" {
-		t.Errorf("expected TokenExec=%q, got %q", "!echo mytoken", ds.TokenExec)
+	if ds.TokenExec != "echo mytoken" {
+		t.Errorf("expected TokenExec=%q, got %q", "echo mytoken", ds.TokenExec)
 	}
 
 	resolved, err := ds.ResolveToken("github.com")

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -317,7 +317,10 @@ func TokenForDomain(domain string) string {
 	if err != nil || cfg == nil {
 		return ""
 	}
-	token, _ := cfg.Domains[domain].ResolveToken(domain)
+	token, err := cfg.Domains[domain].ResolveToken(domain)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "forge: token command for %s failed: %v\n", domain, err)
+	}
 	return token
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -317,7 +317,8 @@ func TokenForDomain(domain string) string {
 	if err != nil || cfg == nil {
 		return ""
 	}
-	return cfg.Domains[domain].Token
+	token, _ := cfg.Domains[domain].ResolveToken(domain)
+	return token
 }
 
 // TokenForDomainEnv looks up a token from environment variables only.

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -2,6 +2,7 @@ package resolve
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -130,6 +131,48 @@ func TestTokenForDomain(t *testing.T) {
 	}
 	t.Setenv("FORGEJO_TOKEN", "")
 	t.Setenv("GITEA_TOKEN", "")
+}
+
+func TestTokenForDomainLogsFailingCommand(t *testing.T) {
+	clearTokenEnv(t)
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	config.ResetCache()
+	defer config.ResetCache()
+
+	cfgDir := filepath.Join(dir, "forge")
+	_ = os.MkdirAll(cfgDir, 0700)
+	_ = os.WriteFile(filepath.Join(cfgDir, "config"), []byte(`[example.com]
+token-cmd = false
+`), 0600)
+
+	// Redirect os.Stderr to capture the log line.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	got := TokenForDomain("example.com")
+
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	out, _ := io.ReadAll(r)
+	_ = r.Close()
+
+	if got != "" {
+		t.Errorf("expected empty token on command failure, got %q", got)
+	}
+	logged := string(out)
+	if !strings.Contains(logged, "example.com") {
+		t.Errorf("expected domain in error log, got: %s", logged)
+	}
+	if !strings.Contains(logged, "failed") {
+		t.Errorf("expected \"failed\" in error log, got: %s", logged)
+	}
 }
 
 func TestTokenForDomainEnvSpecificOverridesFallback(t *testing.T) {


### PR DESCRIPTION
closes #67 

Instead of storing a token in plain text, a config entry can now reference a shell command prefixed with !. The command is executed at runtime and its stdout is used as the token, enabling integration with password managers such as `rbw` or `pass`.

`forge auth login` gains a Ctrl+E shortcut at the token prompt to enter a command interactively.

`forge auth status` displays the command.
