### PR TITLE
Support token-cmd on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ token = abc123
 
 ### Token commands
 
-Instead of a literal `token`, use `token-cmd` to specify a shell command (not supported on Windows).
-The command is executed via `sh -c` each time forge needs the token and its
-stdout is used as the value. This lets you fetch secrets from a password manager
-instead of storing them in plain text:
+Instead of a literal `token`, use `token-cmd` to specify a shell command.
+The command is executed via `sh -c` (Unix) or `%COMSPEC% /c` (Windows) each
+time forge needs the token and its stdout is used as the value. This lets you
+fetch secrets from a password manager instead of storing them in plain text:
 
 ```ini
 [github.com]
@@ -96,8 +96,9 @@ token-cmd = pass show forge/gitlab
 token-cmd = rbw get --raw myhostedgitlab | jq -r '.fields | map(select(.name == "token"))[0].value'
 ```
 
-The variable `FORGE_DOMAIN` is set to the domain name when the command runs,
-so a single command can serve multiple domains:
+The variable `FORGE_DOMAIN` is set to the domain name when the command runs
+(reference it as `$FORGE_DOMAIN` on Unix, `%FORGE_DOMAIN%` on Windows), so a
+single command can serve multiple domains:
 
 ```ini
 [github.com]

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -84,7 +84,7 @@ func authLoginCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&domain, "domain", "", "Forge domain (e.g. github.com, gitea.example.com)")
 	cmd.Flags().StringVar(&token, "token", "", "API token")
-	cmd.Flags().StringVar(&tokenCmd, "token-cmd", "", "Shell command whose stdout is used as the token (Unix only)")
+	cmd.Flags().StringVar(&tokenCmd, "token-cmd", "", "Shell command whose stdout is used as the token")
 	cmd.Flags().StringVar(&forgeType, "type", "", "Forge type: github, gitlab, gitea, forgejo, bitbucket")
 	cmd.MarkFlagsMutuallyExclusive("token", "token-cmd")
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,21 +105,28 @@ func parseGitProtocol(v string) (string, error) {
 	}
 }
 
-// execValue runs cmd via sh -c and returns its trimmed stdout.
+// execValue runs cmd via the platform shell (sh -c on Unix, %COMSPEC% /c on
+// Windows) and returns its trimmed stdout.
 // Shell features (pipes, quotes, substitutions) are supported.
 // FORGE_DOMAIN is set to domain in the command environment.
 // Stdin and stderr are wired to the terminal so interactive prompts
 // (e.g. pinentry, rbw unlock) work and error output is visible directly.
 func execValue(cmd, domain string) (string, error) {
-	if runtime.GOOS == goosWindows {
-		return "", fmt.Errorf("token-cmd is not supported on Windows")
-	}
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return "", fmt.Errorf("empty command")
 	}
 	var stdout strings.Builder
-	c := exec.Command("sh", "-c", cmd)
+	var c *exec.Cmd
+	if runtime.GOOS == goosWindows {
+		shell := os.Getenv("COMSPEC")
+		if shell == "" {
+			shell = "cmd"
+		}
+		c = exec.Command(shell, "/c", cmd)
+	} else {
+		c = exec.Command("sh", "-c", cmd)
+	}
 	c.Env = append(os.Environ(), "FORGE_DOMAIN="+domain)
 	c.Stdin = os.Stdin
 	c.Stdout = &stdout

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -531,10 +531,14 @@ token-cmd = rbw get github-token
 }
 
 func TestLoadFileTokenCommandForgeDomain(t *testing.T) {
+	tokenCmd := "echo $FORGE_DOMAIN"
+	if runtime.GOOS == goosWindows {
+		tokenCmd = "echo %FORGE_DOMAIN%"
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	_ = os.WriteFile(path, []byte(`[gitlab.example.com]
-token-cmd = echo $FORGE_DOMAIN
+token-cmd = `+tokenCmd+`
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}
@@ -555,7 +559,7 @@ func TestLoadFileTokenCommandFails(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	_ = os.WriteFile(path, []byte(`[github.com]
-token-cmd = false
+token-cmd = exit 1
 `), 0600)
 
 	cfg := &Config{Domains: make(map[string]DomainSection)}


### PR DESCRIPTION
PR #124 added `token-cmd` but returned an error on Windows since it shells out via `sh -c`. The tests for the happy path weren't skipped there, so `windows-latest` has been red on main since it merged (visible on the dependabot PRs).

Rather than skip the tests, run the command via `%COMSPEC% /c` on Windows so `token-cmd` works everywhere. Tests now use portable commands (`exit 1` instead of `false`, `%FORGE_DOMAIN%` for the env-var expansion check on Windows). README and `--token-cmd` flag help updated to drop the Unix-only caveat.