### PR TITLE
Consolidate git config helpers

### DIFF
--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -669,7 +668,7 @@ The argument can be a PR number or a full URL:
 			// Cache the PR number for the branch only after a successful
 			// checkout, so a failed checkout doesn't leave a stale entry.
 			if !flagDetach {
-				_ = storePRForBranch(ctx, localBranch, number)
+				_ = git.SetPRNumber(ctx, "", localBranch, number)
 				if pr.Base.Ref != "" {
 					_ = git.SetBaseBranch(ctx, "", localBranch, pr.Base.Ref)
 				}
@@ -829,17 +828,16 @@ func gitCheckout(ctx context.Context, remote, remoteRef, localBranch string, det
 }
 
 func findPRForCurrentBranch(ctx context.Context, f forges.Forge, owner, repo string) (int, error) {
-	out, err := exec.CommandContext(ctx, "git", "branch", "--show-current").Output()
+	localBranch, err := git.CurrentBranch(ctx, "")
 	if err != nil {
-		return 0, fmt.Errorf("getting current branch: %w (not in a git repository?)", err)
+		return 0, fmt.Errorf("%w (not in a git repository?)", err)
 	}
-	localBranch := strings.TrimSpace(string(out))
 	if localBranch == "" {
 		return 0, fmt.Errorf("not on a branch (detached HEAD state)")
 	}
 
 	// Check cache first (set by 'pr checkout')
-	if n, err := loadPRForBranch(ctx, localBranch); err == nil {
+	if n, err := git.GetPRNumber(ctx, "", localBranch); err == nil {
 		return n, nil
 	}
 
@@ -889,40 +887,11 @@ func findPRForCurrentBranch(ctx context.Context, f forges.Forge, owner, repo str
 		if pr.State == "open" {
 			// Store the PR number into local git config so that the next 'forge
 			// pr view' call is a lot faster.
-			_ = storePRForBranch(ctx, localBranch, pr.Number)
+			_ = git.SetPRNumber(ctx, "", localBranch, pr.Number)
 			return pr.Number, nil
 		}
 	}
 
 	// No open PR, return the first match (closed/merged) but don't cache it
 	return matching[0].Number, nil
-}
-
-func storePRForBranch(ctx context.Context, branch string, number int) error {
-	key := fmt.Sprintf("branch.%s.forge-pr", branch)
-	return exec.CommandContext(ctx, "git", "config", "--local", key, strconv.Itoa(number)).Run()
-}
-
-var prRefRE = regexp.MustCompile(`^refs/pull/(\d+)/head$`)
-
-func loadPRForBranch(ctx context.Context, branch string) (int, error) {
-	key := fmt.Sprintf("branch.%s.forge-pr", branch)
-	out, err := exec.CommandContext(ctx, "git", "config", "--get", key).Output()
-	if err == nil {
-		return strconv.Atoi(strings.TrimSpace(string(out)))
-	}
-
-	// Fall back to gh CLI's format (refs/pull/<n>/head in branch.<name>.merge).
-	// The regex only matches refs/pull/<n>/head, so refs/heads/* values are
-	// safely rejected.
-	mergeKey := fmt.Sprintf("branch.%s.merge", branch)
-	out, err = exec.CommandContext(ctx, "git", "config", "--get", mergeKey).Output()
-	if err != nil {
-		return 0, err
-	}
-	m := prRefRE.FindStringSubmatch(strings.TrimSpace(string(out)))
-	if m == nil {
-		return 0, fmt.Errorf("not a PR ref")
-	}
-	return strconv.Atoi(m[1])
 }

--- a/internal/cli/pr_test.go
+++ b/internal/cli/pr_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge/internal/git"
 	"github.com/git-pkgs/forge/internal/resolve"
 )
 
@@ -138,74 +139,6 @@ func TestPRDiffRequiresArg(t *testing.T) {
 	}
 }
 
-func TestStorePRForBranch(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not installed")
-	}
-
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	mustGit(t, dir, "init", "-q")
-	mustGit(t, dir, "config", "user.email", "test@test.com")
-	mustGit(t, dir, "config", "user.name", "Test")
-
-	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	mustGit(t, dir, "add", "README")
-	mustGit(t, dir, "commit", "-m", "init")
-	mustGit(t, dir, "checkout", "-b", "feature")
-
-	ctx := context.Background()
-
-	// Store PR number
-	if err := storePRForBranch(ctx, "feature", 42); err != nil {
-		t.Fatalf("storePRForBranch: %v", err)
-	}
-
-	// Load it back
-	n, err := loadPRForBranch(ctx, "feature")
-	if err != nil {
-		t.Fatalf("loadPRForBranch: %v", err)
-	}
-	if n != 42 {
-		t.Errorf("got %d, want 42", n)
-	}
-}
-
-func TestLoadPRForBranchGhFormat(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not installed")
-	}
-
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	mustGit(t, dir, "init", "-q")
-	mustGit(t, dir, "config", "user.email", "test@test.com")
-	mustGit(t, dir, "config", "user.name", "Test")
-
-	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	mustGit(t, dir, "add", "README")
-	mustGit(t, dir, "commit", "-m", "init")
-	mustGit(t, dir, "checkout", "-b", "pr-branch")
-
-	// Set up gh CLI's format: branch.<name>.merge = refs/pull/<n>/head
-	mustGit(t, dir, "config", "branch.pr-branch.merge", "refs/pull/123/head")
-
-	ctx := context.Background()
-	n, err := loadPRForBranch(ctx, "pr-branch")
-	if err != nil {
-		t.Fatalf("loadPRForBranch: %v", err)
-	}
-	if n != 123 {
-		t.Errorf("got %d, want 123", n)
-	}
-}
-
 func TestFindPRForCurrentBranch(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")
@@ -260,9 +193,9 @@ func TestFindPRForCurrentBranch(t *testing.T) {
 	}
 
 	// The PR number should now be cached
-	cached, err := loadPRForBranch(ctx, "feature")
+	cached, err := git.GetPRNumber(ctx, "", "feature")
 	if err != nil {
-		t.Fatalf("loadPRForBranch after find: %v", err)
+		t.Fatalf("git.GetPRNumber after find: %v", err)
 	}
 	if cached != 99 {
 		t.Errorf("cached PR = %d, want 99", cached)
@@ -330,9 +263,9 @@ func TestFindPRForCurrentBranch_OpenWinsOverClosed(t *testing.T) {
 	}
 
 	// The open PR should be cached
-	cached, err := loadPRForBranch(ctx, "feature")
+	cached, err := git.GetPRNumber(ctx, "", "feature")
 	if err != nil {
-		t.Fatalf("loadPRForBranch after find: %v", err)
+		t.Fatalf("git.GetPRNumber after find: %v", err)
 	}
 	if cached != 99 {
 		t.Errorf("cached PR = %d, want 99", cached)
@@ -392,10 +325,10 @@ func TestFindPRForCurrentBranch_ClosedPRNotCached(t *testing.T) {
 		t.Errorf("got %d, want 42 (the closed PR should be returned)", n)
 	}
 
-	// Closed PRs should NOT be cached - loadPRForBranch should find nothing
-	_, err = loadPRForBranch(ctx, "feature")
+	// Closed PRs should NOT be cached - GetPRNumber should find nothing
+	_, err = git.GetPRNumber(ctx, "", "feature")
 	if err == nil {
-		t.Error("expected loadPRForBranch to return error for uncached closed PR, got nil")
+		t.Error("expected git.GetPRNumber to return error for uncached closed PR, got nil")
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,10 +5,19 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/git-pkgs/forge"
 )
+
+const (
+	forgeMergeBaseKey = "forge-merge-base"
+	forgePRKey        = "forge-pr"
+)
+
+var prRefRE = regexp.MustCompile(`^refs/pull/(\d+)/head$`)
 
 // GetOrFetchBaseBranch returns the base branch of the given branch.
 // It first checks the local git configuration for a cached value.
@@ -17,9 +26,9 @@ import (
 // If branch is empty, it uses the current branch.
 func GetOrFetchBaseBranch(ctx context.Context, f forges.Forge, dir, owner, repo, branch string, forceRefresh bool) (string, error) {
 	if branch == "" {
-		curr, err := runGit(ctx, dir, "branch", "--show-current")
+		curr, err := CurrentBranch(ctx, dir)
 		if err != nil {
-			return "", fmt.Errorf("failed to get current branch: %w", err)
+			return "", err
 		}
 		branch = curr
 	}
@@ -28,7 +37,7 @@ func GetOrFetchBaseBranch(ctx context.Context, f forges.Forge, dir, owner, repo,
 	}
 
 	// 1. Check local git config
-	configKey := fmt.Sprintf("branch.%s.forge-merge-base", branch)
+	configKey := branchConfigKey(branch, forgeMergeBaseKey)
 	if !forceRefresh {
 		if cached, err := runGit(ctx, dir, "config", "--get", configKey); err == nil && cached != "" {
 			return cached, nil
@@ -73,9 +82,57 @@ func SetBaseBranch(ctx context.Context, dir, branch, base string) error {
 	if base == "" {
 		return fmt.Errorf("empty base branch name")
 	}
-	configKey := fmt.Sprintf("branch.%s.forge-merge-base", branch)
+	configKey := branchConfigKey(branch, forgeMergeBaseKey)
 	_, err := runGit(ctx, dir, "config", "--local", configKey, base)
 	return err
+}
+
+// SetPRNumber caches the pull request number for a branch in the local git configuration.
+func SetPRNumber(ctx context.Context, dir, branch string, number int) error {
+	if branch == "" {
+		return fmt.Errorf("empty branch name")
+	}
+	if number <= 0 {
+		return fmt.Errorf("invalid pull request number %d", number)
+	}
+	_, err := runGit(ctx, dir, "config", "--local", branchConfigKey(branch, forgePRKey), strconv.Itoa(number))
+	return err
+}
+
+// GetPRNumber returns the cached pull request number for a branch.
+func GetPRNumber(ctx context.Context, dir, branch string) (int, error) {
+	if branch == "" {
+		return 0, fmt.Errorf("empty branch name")
+	}
+	if out, err := runGit(ctx, dir, "config", "--get", branchConfigKey(branch, forgePRKey)); err == nil {
+		return strconv.Atoi(out)
+	}
+
+	// Fall back to gh CLI's format (refs/pull/<n>/head in branch.<name>.merge).
+	// The regex only matches refs/pull/<n>/head, so refs/heads/* values are
+	// safely rejected.
+	out, err := runGit(ctx, dir, "config", "--get", branchConfigKey(branch, "merge"))
+	if err != nil {
+		return 0, err
+	}
+	m := prRefRE.FindStringSubmatch(out)
+	if m == nil {
+		return 0, fmt.Errorf("not a PR ref")
+	}
+	return strconv.Atoi(m[1])
+}
+
+// CurrentBranch returns the current local branch name.
+func CurrentBranch(ctx context.Context, dir string) (string, error) {
+	branch, err := runGit(ctx, dir, "branch", "--show-current")
+	if err != nil {
+		return "", fmt.Errorf("failed to get current branch: %w", err)
+	}
+	return branch, nil
+}
+
+func branchConfigKey(branch, name string) string {
+	return fmt.Sprintf("branch.%s.%s", branch, name)
 }
 
 func runGit(ctx context.Context, dir string, args ...string) (string, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -39,7 +39,7 @@ func GetOrFetchBaseBranch(ctx context.Context, f forges.Forge, dir, owner, repo,
 	// 1. Check local git config
 	configKey := branchConfigKey(branch, forgeMergeBaseKey)
 	if !forceRefresh {
-		if cached, err := runGit(ctx, dir, "config", "--get", configKey); err == nil && cached != "" {
+		if cached, err := getLocalConfig(ctx, dir, configKey); err == nil && cached != "" {
 			return cached, nil
 		}
 	}
@@ -104,14 +104,14 @@ func GetPRNumber(ctx context.Context, dir, branch string) (int, error) {
 	if branch == "" {
 		return 0, fmt.Errorf("empty branch name")
 	}
-	if out, err := runGit(ctx, dir, "config", "--get", branchConfigKey(branch, forgePRKey)); err == nil {
+	if out, err := getLocalConfig(ctx, dir, branchConfigKey(branch, forgePRKey)); err == nil {
 		return strconv.Atoi(out)
 	}
 
 	// Fall back to gh CLI's format (refs/pull/<n>/head in branch.<name>.merge).
 	// The regex only matches refs/pull/<n>/head, so refs/heads/* values are
 	// safely rejected.
-	out, err := runGit(ctx, dir, "config", "--get", branchConfigKey(branch, "merge"))
+	out, err := getLocalConfig(ctx, dir, branchConfigKey(branch, "merge"))
 	if err != nil {
 		return 0, err
 	}
@@ -133,6 +133,10 @@ func CurrentBranch(ctx context.Context, dir string) (string, error) {
 
 func branchConfigKey(branch, name string) string {
 	return fmt.Sprintf("branch.%s.%s", branch, name)
+}
+
+func getLocalConfig(ctx context.Context, dir, key string) (string, error) {
+	return runGit(ctx, dir, "config", "--local", "--get", key)
 }
 
 func runGit(ctx context.Context, dir string, args ...string) (string, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -131,6 +131,35 @@ func TestGetOrFetchBaseBranch(t *testing.T) {
 	}
 }
 
+func TestGetOrFetchBaseBranchIgnoresGlobalConfig(t *testing.T) {
+	dir := initGitRepo(t)
+	isolateGlobalGitConfig(t)
+	mustGit(t, dir, "config", "--global", "branch.feature.forge-merge-base", "main")
+
+	mock := &mockForge{
+		prService: &mockPRService{
+			t:            t,
+			expectedHead: "feature",
+			prs: []forges.PullRequest{
+				{
+					Number: 1,
+					State:  "open",
+					Head:   forges.PRBranch{Ref: "feature"},
+					Base:   forges.PRBranch{Ref: "develop"},
+				},
+			},
+		},
+	}
+
+	got, err := GetOrFetchBaseBranch(context.Background(), mock, dir, "owner", "repo", "feature", false)
+	if err != nil {
+		t.Fatalf("GetOrFetchBaseBranch: %v", err)
+	}
+	if got != "develop" {
+		t.Fatalf("GetOrFetchBaseBranch = %q, want %q", got, "develop")
+	}
+}
+
 func TestCurrentBranch(t *testing.T) {
 	dir := initGitRepo(t)
 	mustGit(t, dir, "checkout", "-b", "feature")
@@ -176,6 +205,26 @@ func TestGetPRNumberGhFormat(t *testing.T) {
 	}
 }
 
+func TestGetPRNumberIgnoresGlobalPRNumber(t *testing.T) {
+	dir := initGitRepo(t)
+	isolateGlobalGitConfig(t)
+	mustGit(t, dir, "config", "--global", "branch.feature.forge-pr", "99")
+
+	if _, err := GetPRNumber(context.Background(), dir, "feature"); err == nil {
+		t.Fatal("expected global forge-pr config to be ignored")
+	}
+}
+
+func TestGetPRNumberIgnoresGlobalGhFormat(t *testing.T) {
+	dir := initGitRepo(t)
+	isolateGlobalGitConfig(t)
+	mustGit(t, dir, "config", "--global", "branch.pr-branch.merge", "refs/pull/123/head")
+
+	if _, err := GetPRNumber(context.Background(), dir, "pr-branch"); err == nil {
+		t.Fatal("expected global gh-format merge config to be ignored")
+	}
+}
+
 func TestGetPRNumberRejectsNonPRMergeRef(t *testing.T) {
 	dir := initGitRepo(t)
 	ctx := context.Background()
@@ -195,6 +244,12 @@ func initGitRepo(t *testing.T) string {
 	dir := t.TempDir()
 	mustGit(t, dir, "init", "-q")
 	return dir
+}
+
+func isolateGlobalGitConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_GLOBAL", t.TempDir()+"/global.gitconfig")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 }
 
 func mustGit(t *testing.T, dir string, args ...string) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -130,3 +130,78 @@ func TestGetOrFetchBaseBranch(t *testing.T) {
 		t.Errorf("expected base branch 'develop', got %q", gotBase)
 	}
 }
+
+func TestCurrentBranch(t *testing.T) {
+	dir := initGitRepo(t)
+	mustGit(t, dir, "checkout", "-b", "feature")
+
+	got, err := CurrentBranch(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+	if got != "feature" {
+		t.Fatalf("CurrentBranch = %q, want %q", got, "feature")
+	}
+}
+
+func TestSetAndGetPRNumber(t *testing.T) {
+	dir := initGitRepo(t)
+	ctx := context.Background()
+
+	if err := SetPRNumber(ctx, dir, "feature", 42); err != nil {
+		t.Fatalf("SetPRNumber: %v", err)
+	}
+
+	got, err := GetPRNumber(ctx, dir, "feature")
+	if err != nil {
+		t.Fatalf("GetPRNumber: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("GetPRNumber = %d, want 42", got)
+	}
+}
+
+func TestGetPRNumberGhFormat(t *testing.T) {
+	dir := initGitRepo(t)
+	ctx := context.Background()
+
+	mustGit(t, dir, "config", "branch.pr-branch.merge", "refs/pull/123/head")
+
+	got, err := GetPRNumber(ctx, dir, "pr-branch")
+	if err != nil {
+		t.Fatalf("GetPRNumber: %v", err)
+	}
+	if got != 123 {
+		t.Fatalf("GetPRNumber = %d, want 123", got)
+	}
+}
+
+func TestGetPRNumberRejectsNonPRMergeRef(t *testing.T) {
+	dir := initGitRepo(t)
+	ctx := context.Background()
+
+	mustGit(t, dir, "config", "branch.feature.merge", "refs/heads/main")
+
+	if _, err := GetPRNumber(ctx, dir, "feature"); err == nil {
+		t.Fatal("expected non-PR merge ref to be rejected")
+	}
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available, skipping test")
+	}
+	dir := t.TempDir()
+	mustGit(t, dir, "init", "-q")
+	return dir
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #127

This refactors branch-specific git config access into `internal/git` so CLI code no longer shells out directly for PR cache and current branch lookup behavior.

## Changes

- Add `git.CurrentBranch` for shared current branch lookup.
- Add `git.SetPRNumber` and `git.GetPRNumber` for `branch.<name>.forge-pr` handling.
- Preserve fallback support for GitHub CLI-style `branch.<name>.merge = refs/pull/<n>/head`.
- Route `pr view` / `pr checkout` cache behavior through `internal/git`.
- Move PR config helper tests from CLI coverage into `internal/git`.

## Testing

```bash
go test ./internal/git ./internal/cli
go test ./...
git diff --check
```