### PR TITLE
fix(repo): make --limit cap total results

### DIFF
--- a/internal/cli/pr_checkout_test.go
+++ b/internal/cli/pr_checkout_test.go
@@ -75,10 +75,11 @@ func (m *mockPRService) ListURL(_ string) string {
 
 // mockForge implements forges.Forge for testing.
 type mockForge struct {
-	prService *mockPRService
+	prService   *mockPRService
+	repoService forges.RepoService
 }
 
-func (m *mockForge) Repos() forges.RepoService                  { return nil }
+func (m *mockForge) Repos() forges.RepoService                  { return m.repoService }
 func (m *mockForge) Issues() forges.IssueService                { return nil }
 func (m *mockForge) PullRequests() forges.PullRequestService    { return m.prService }
 func (m *mockForge) Labels() forges.LabelService                { return nil }

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -178,6 +178,9 @@ func repoListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if flagLimit > 0 && len(repos) > flagLimit {
+				repos = repos[:flagLimit]
+			}
 
 			p := printer()
 			if p.Format == output.JSON {
@@ -620,15 +623,19 @@ func repoSearchCmd() *cobra.Command {
 			}
 
 			opts := forges.SearchRepoOpts{
-				Query: args[0],
-				Sort:  flagSort,
-				Order: flagOrder,
-				Limit: flagLimit,
+				Query:   args[0],
+				Sort:    flagSort,
+				Order:   flagOrder,
+				Limit:   flagLimit,
+				PerPage: flagLimit,
 			}
 
 			repos, err := forge.Repos().Search(cmd.Context(), opts)
 			if err != nil {
 				return notSupported(err, "repository search")
+			}
+			if flagLimit > 0 && len(repos) > flagLimit {
+				repos = repos[:flagLimit]
 			}
 
 			p := printer()

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -159,7 +159,7 @@ func repoListCmd() *cobra.Command {
 			}
 
 			opts := forges.ListRepoOpts{
-				PerPage: flagLimit,
+				Limit: flagLimit,
 			}
 			if flagNoArchived {
 				opts.Archived = forges.ArchivedExclude
@@ -620,10 +620,10 @@ func repoSearchCmd() *cobra.Command {
 			}
 
 			opts := forges.SearchRepoOpts{
-				Query:   args[0],
-				Sort:    flagSort,
-				Order:   flagOrder,
-				PerPage: flagLimit,
+				Query: args[0],
+				Sort:  flagSort,
+				Order: flagOrder,
+				Limit: flagLimit,
 			}
 
 			repos, err := forge.Repos().Search(cmd.Context(), opts)

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"slices"
 	"strings"
 	"testing"
+
+	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge/internal/resolve"
 )
 
 func TestRepoCmd(t *testing.T) {
@@ -81,6 +85,60 @@ func TestRepoEditMutuallyExclusiveVisibility(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("expected 'mutually exclusive' in error, got: %s", err)
+	}
+}
+
+func TestRepoListLimitCapsTotalResults(t *testing.T) {
+	repos := &capturingRepoService{}
+	setupRepoCommandTest(t, repos)
+
+	cmd := repoListCmd()
+	cmd.SetArgs([]string{"octocat", "--limit", "7"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repo list: %v", err)
+	}
+
+	if !repos.listCalled {
+		t.Fatal("expected Repos().List to be called")
+	}
+	if repos.listOwner != "octocat" {
+		t.Fatalf("owner = %q, want octocat", repos.listOwner)
+	}
+	if repos.listOpts.Limit != 7 {
+		t.Fatalf("Limit = %d, want 7", repos.listOpts.Limit)
+	}
+	if repos.listOpts.PerPage != 0 {
+		t.Fatalf("PerPage = %d, want 0", repos.listOpts.PerPage)
+	}
+}
+
+func TestRepoSearchLimitCapsTotalResults(t *testing.T) {
+	repos := &capturingRepoService{}
+	setupRepoCommandTest(t, repos)
+
+	cmd := repoSearchCmd()
+	cmd.SetArgs([]string{"terminal", "--limit", "5", "--sort", "stars", "--order", "desc"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repo search: %v", err)
+	}
+
+	if !repos.searchCalled {
+		t.Fatal("expected Repos().Search to be called")
+	}
+	if repos.searchOpts.Query != "terminal" {
+		t.Fatalf("Query = %q, want terminal", repos.searchOpts.Query)
+	}
+	if repos.searchOpts.Sort != "stars" {
+		t.Fatalf("Sort = %q, want stars", repos.searchOpts.Sort)
+	}
+	if repos.searchOpts.Order != "desc" {
+		t.Fatalf("Order = %q, want desc", repos.searchOpts.Order)
+	}
+	if repos.searchOpts.Limit != 5 {
+		t.Fatalf("Limit = %d, want 5", repos.searchOpts.Limit)
+	}
+	if repos.searchOpts.PerPage != 0 {
+		t.Fatalf("PerPage = %d, want 0", repos.searchOpts.PerPage)
 	}
 }
 
@@ -172,4 +230,93 @@ func TestGitCloneArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupRepoCommandTest(t *testing.T, repos *capturingRepoService) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("FORGE_HOST", "")
+
+	flagRepo = ""
+	flagForgeType = ""
+	flagHost = ""
+	flagOutput = "plain"
+	flagRemote = ""
+
+	resolve.SetTestForge(&mockForge{repoService: repos}, "", "", "github.com")
+	t.Cleanup(resolve.ResetTestForge)
+}
+
+type capturingRepoService struct {
+	listCalled   bool
+	listOwner    string
+	listOpts     forges.ListRepoOpts
+	searchCalled bool
+	searchOpts   forges.SearchRepoOpts
+}
+
+func (m *capturingRepoService) Get(_ context.Context, _, _ string) (*forges.Repository, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) List(_ context.Context, owner string, opts forges.ListRepoOpts) ([]forges.Repository, error) {
+	m.listCalled = true
+	m.listOwner = owner
+	m.listOpts = opts
+	return []forges.Repository{}, nil
+}
+
+func (m *capturingRepoService) Create(_ context.Context, _ forges.CreateRepoOpts) (*forges.Repository, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) Edit(_ context.Context, _, _ string, _ forges.EditRepoOpts) (*forges.Repository, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) Delete(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (m *capturingRepoService) Fork(_ context.Context, _, _ string, _ forges.ForkRepoOpts) (*forges.Repository, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) ListForks(_ context.Context, _, _ string, _ forges.ListForksOpts) ([]forges.Repository, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) ListTags(_ context.Context, _, _ string) ([]forges.Tag, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) ListContributors(_ context.Context, _, _ string) ([]forges.Contributor, error) {
+	return nil, nil
+}
+
+func (m *capturingRepoService) Search(_ context.Context, opts forges.SearchRepoOpts) ([]forges.Repository, error) {
+	m.searchCalled = true
+	m.searchOpts = opts
+	return []forges.Repository{}, nil
+}
+
+func (m *capturingRepoService) SettingsURL(repoHTMLURL string) string {
+	return repoHTMLURL + "/settings"
+}
+
+func (m *capturingRepoService) WikiURL(repoHTMLURL string) string {
+	return repoHTMLURL + "/wiki"
+}
+
+func (m *capturingRepoService) ActionsURL(repoHTMLURL string) string {
+	return repoHTMLURL + "/actions"
+}
+
+func (m *capturingRepoService) ReleasesURL(repoHTMLURL string) string {
+	return repoHTMLURL + "/releases"
+}
+
+func (m *capturingRepoService) BlobURL(repoHTMLURL, ref, path string) string {
+	return repoHTMLURL + "/blob/" + ref + "/" + path
 }

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge/internal/config"
 	"github.com/git-pkgs/forge/internal/resolve"
 )
 
@@ -237,6 +238,8 @@ func setupRepoCommandTest(t *testing.T, repos *capturingRepoService) {
 	t.Chdir(t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("FORGE_HOST", "")
+	config.ResetCache()
+	t.Cleanup(config.ResetCache)
 
 	flagRepo = ""
 	flagForgeType = ""

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -90,12 +93,13 @@ func TestRepoEditMutuallyExclusiveVisibility(t *testing.T) {
 }
 
 func TestRepoListLimitCapsTotalResults(t *testing.T) {
-	repos := &capturingRepoService{}
+	repos := &capturingRepoService{listRepos: testRepositories(10)}
 	setupRepoCommandTest(t, repos)
 
 	cmd := repoListCmd()
 	cmd.SetArgs([]string{"octocat", "--limit", "7"})
-	if err := cmd.Execute(); err != nil {
+	stdout, err := captureStdout(t, cmd.Execute)
+	if err != nil {
 		t.Fatalf("repo list: %v", err)
 	}
 
@@ -111,15 +115,17 @@ func TestRepoListLimitCapsTotalResults(t *testing.T) {
 	if repos.listOpts.PerPage != 0 {
 		t.Fatalf("PerPage = %d, want 0", repos.listOpts.PerPage)
 	}
+	assertOutputLineCount(t, stdout, 7)
 }
 
 func TestRepoSearchLimitCapsTotalResults(t *testing.T) {
-	repos := &capturingRepoService{}
+	repos := &capturingRepoService{searchRepos: testRepositories(10)}
 	setupRepoCommandTest(t, repos)
 
 	cmd := repoSearchCmd()
 	cmd.SetArgs([]string{"terminal", "--limit", "5", "--sort", "stars", "--order", "desc"})
-	if err := cmd.Execute(); err != nil {
+	stdout, err := captureStdout(t, cmd.Execute)
+	if err != nil {
 		t.Fatalf("repo search: %v", err)
 	}
 
@@ -138,9 +144,10 @@ func TestRepoSearchLimitCapsTotalResults(t *testing.T) {
 	if repos.searchOpts.Limit != 5 {
 		t.Fatalf("Limit = %d, want 5", repos.searchOpts.Limit)
 	}
-	if repos.searchOpts.PerPage != 0 {
-		t.Fatalf("PerPage = %d, want 0", repos.searchOpts.PerPage)
+	if repos.searchOpts.PerPage != 5 {
+		t.Fatalf("PerPage = %d, want 5", repos.searchOpts.PerPage)
 	}
+	assertOutputLineCount(t, stdout, 5)
 }
 
 func TestDomainFromFlags(t *testing.T) {
@@ -255,8 +262,10 @@ type capturingRepoService struct {
 	listCalled   bool
 	listOwner    string
 	listOpts     forges.ListRepoOpts
+	listRepos    []forges.Repository
 	searchCalled bool
 	searchOpts   forges.SearchRepoOpts
+	searchRepos  []forges.Repository
 }
 
 func (m *capturingRepoService) Get(_ context.Context, _, _ string) (*forges.Repository, error) {
@@ -267,7 +276,7 @@ func (m *capturingRepoService) List(_ context.Context, owner string, opts forges
 	m.listCalled = true
 	m.listOwner = owner
 	m.listOpts = opts
-	return []forges.Repository{}, nil
+	return m.listRepos, nil
 }
 
 func (m *capturingRepoService) Create(_ context.Context, _ forges.CreateRepoOpts) (*forges.Repository, error) {
@@ -301,7 +310,56 @@ func (m *capturingRepoService) ListContributors(_ context.Context, _, _ string) 
 func (m *capturingRepoService) Search(_ context.Context, opts forges.SearchRepoOpts) ([]forges.Repository, error) {
 	m.searchCalled = true
 	m.searchOpts = opts
-	return []forges.Repository{}, nil
+	return m.searchRepos, nil
+}
+
+func testRepositories(count int) []forges.Repository {
+	repos := make([]forges.Repository, count)
+	for i := range repos {
+		repos[i] = forges.Repository{FullName: fmt.Sprintf("octocat/repo-%02d", i+1)}
+	}
+	return repos
+}
+
+func captureStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stdout pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := run()
+	closeErr := w.Close()
+	os.Stdout = oldStdout
+
+	out, readErr := io.ReadAll(r)
+	if err := r.Close(); err != nil {
+		t.Fatalf("closing stdout reader: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("closing stdout writer: %v", closeErr)
+	}
+	if readErr != nil {
+		t.Fatalf("reading stdout: %v", readErr)
+	}
+	return string(out), runErr
+}
+
+func assertOutputLineCount(t *testing.T, stdout string, want int) {
+	t.Helper()
+
+	got := 0
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if line != "" {
+			got++
+		}
+	}
+	if got != want {
+		t.Fatalf("printed %d lines, want %d; stdout:\n%s", got, want, stdout)
+	}
 }
 
 func (m *capturingRepoService) SettingsURL(repoHTMLURL string) string {

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -64,8 +64,9 @@ func SetForgeType(forgeType string) {
 	}
 }
 
-// SetTestForge configures a mock forge for testing. When set, Repo() returns
-// this forge directly without network or git resolution.
+// SetTestForge configures a mock forge for testing. When set, Repo() and
+// ForgeForDomain() return this forge directly without network or git
+// resolution.
 func SetTestForge(forge forges.Forge, owner, repo, domain string) {
 	testForge = forge
 	testOwner = owner
@@ -362,6 +363,9 @@ func TokenForDomainEnv(domain string) string {
 // ForgeForDomain returns a Forge instance for the given domain.
 // If the domain isn't a known forge, it checks config then probes the server.
 func ForgeForDomain(domain string) (forges.Forge, error) {
+	if testForge != nil && (testDomain == "" || testDomain == domain) {
+		return testForge, nil
+	}
 	client := newClient(domain)
 	return forgeForDomainMaybeConfig(context.Background(), client, domain)
 }

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -64,9 +64,8 @@ func SetForgeType(forgeType string) {
 	}
 }
 
-// SetTestForge configures a mock forge for testing. When set, Repo() and
-// ForgeForDomain() return this forge directly without network or git
-// resolution.
+// SetTestForge configures a mock forge for testing. Repo() returns it directly;
+// ForgeForDomain() returns it when the requested domain matches the test domain.
 func SetTestForge(forge forges.Forge, owner, repo, domain string) {
 	testForge = forge
 	testOwner = owner


### PR DESCRIPTION
## Summary

- Cap `repo list --limit` output after the repo service returns results.
- Keep `repo search --limit` as both `SearchRepoOpts.Limit` and `PerPage`, then cap output after the search call.
- Cover both paths with CLI tests that return more repos than the limit and assert the printed row count.

## Why

Fixes #133. `--limit` should cap the total number of repositories printed. Search still uses the limit as the backend page size because the current search backends fetch one page.

## Validation

- `go test ./internal/cli -run 'TestRepo(List|Search)LimitCapsTotalResults' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./... -count=1`
- `git diff --check`