### PR TITLE
fix forge api base url construction

### DIFF
--- a/bitbucket/bitbucket.go
+++ b/bitbucket/bitbucket.go
@@ -47,6 +47,10 @@ func New(token string, hc *http.Client) forge.Forge {
 	return &bitbucketForge{token: token, httpClient: hc}
 }
 
+func (f *bitbucketForge) APIBaseURL() string {
+	return bitbucketAPI
+}
+
 type bitbucketRepoService struct {
 	token      string
 	httpClient *http.Client

--- a/forge.go
+++ b/forge.go
@@ -50,6 +50,12 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("forge: HTTP %d from %s", e.StatusCode, e.URL)
 }
 
+// APIBaseURLProvider is implemented by forge backends that can expose their
+// raw API root URL for arbitrary endpoint requests.
+type APIBaseURLProvider interface {
+	APIBaseURL() string
+}
+
 // Forge is the interface each forge backend implements.
 type Forge interface {
 	Repos() RepoService

--- a/gitea/gitea.go
+++ b/gitea/gitea.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	forge "github.com/git-pkgs/forge"
 	"net/http"
+	"strings"
 
 	"code.gitea.io/sdk/gitea"
 )
@@ -32,6 +33,10 @@ func New(baseURL, token string, hc *http.Client) forge.Forge {
 	}
 	c, _ := gitea.NewClient(baseURL, opts...)
 	return &giteaForge{client: c, baseURL: baseURL, token: token, httpClient: hc}
+}
+
+func (f *giteaForge) APIBaseURL() string {
+	return strings.TrimRight(f.baseURL, "/") + "/api/v1"
 }
 
 type giteaRepoService struct {

--- a/github/github.go
+++ b/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	forge "github.com/git-pkgs/forge"
 	"net/http"
+	"strings"
 
 	"github.com/google/go-github/v82/github"
 )
@@ -11,7 +12,8 @@ import (
 const defaultPageSize = 100
 
 type gitHubForge struct {
-	client *github.Client
+	client     *github.Client
+	apiBaseURL string
 }
 
 // New creates a GitHub forge backend for github.com.
@@ -20,14 +22,18 @@ func New(token string, hc *http.Client) forge.Forge {
 	if token != "" {
 		c = c.WithAuthToken(token)
 	}
-	return &gitHubForge{client: c}
+	return &gitHubForge{client: c, apiBaseURL: "https://api.github.com"}
 }
 
 // NewWithBase creates a GitHub forge backend for a GitHub Enterprise instance.
 func NewWithBase(baseURL, token string, hc *http.Client) forge.Forge {
 	c := github.NewClient(hc).WithAuthToken(token)
 	c, _ = c.WithEnterpriseURLs(baseURL, baseURL)
-	return &gitHubForge{client: c}
+	return &gitHubForge{client: c, apiBaseURL: strings.TrimRight(baseURL, "/") + "/api/v3"}
+}
+
+func (f *gitHubForge) APIBaseURL() string {
+	return f.apiBaseURL
 }
 
 type gitHubRepoService struct {

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -4,24 +4,31 @@ import (
 	"context"
 	forge "github.com/git-pkgs/forge"
 	"net/http"
+	"strings"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 type gitLabForge struct {
-	client *gitlab.Client
+	client     *gitlab.Client
+	apiBaseURL string
 }
 
 // New creates a GitLab forge backend.
 func New(baseURL, token string, hc *http.Client) forge.Forge {
+	apiBaseURL := strings.TrimRight(baseURL, "/") + "/api/v4"
 	opts := []gitlab.ClientOptionFunc{
-		gitlab.WithBaseURL(baseURL + "/api/v4"),
+		gitlab.WithBaseURL(apiBaseURL),
 	}
 	if hc != nil {
 		opts = append(opts, gitlab.WithHTTPClient(hc))
 	}
 	c, _ := gitlab.NewClient(token, opts...)
-	return &gitLabForge{client: c}
+	return &gitLabForge{client: c, apiBaseURL: apiBaseURL}
+}
+
+func (f *gitLabForge) APIBaseURL() string {
+	return f.apiBaseURL
 }
 
 type gitLabRepoService struct {

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -32,19 +32,7 @@ var apiCmd = &cobra.Command{
 		endpoint = strings.ReplaceAll(endpoint, "{owner}", owner)
 		endpoint = strings.ReplaceAll(endpoint, "{repo}", repoName)
 
-		// Build full URL
-		var baseURL string
-		switch {
-		case strings.Contains(domain, "github"):
-			baseURL = "https://api." + domain
-		case strings.Contains(domain, "gitlab"):
-			baseURL = "https://" + domain + "/api/v4"
-		case strings.Contains(domain, "bitbucket"):
-			baseURL = "https://api.bitbucket.org/2.0"
-		default:
-			baseURL = "https://" + domain + "/api/v1"
-		}
-
+		baseURL := apiBaseURL(domain, flagForgeType)
 		url := baseURL + "/" + strings.TrimLeft(endpoint, "/")
 
 		var body io.Reader
@@ -127,6 +115,21 @@ var apiCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func apiBaseURL(domain, forgeType string) string {
+	_ = forgeType
+
+	switch {
+	case strings.Contains(domain, "github"):
+		return "https://api." + domain
+	case strings.Contains(domain, "gitlab"):
+		return "https://" + domain + "/api/v4"
+	case strings.Contains(domain, "bitbucket"):
+		return "https://api.bitbucket.org/2.0"
+	default:
+		return "https://" + domain + "/api/v1"
+	}
 }
 
 var (

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/git-pkgs/forge/internal/config"
+	forges "github.com/git-pkgs/forge"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +24,7 @@ var apiCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endpoint := args[0]
 
-		_, owner, repoName, domain, err := resolve.Repo(flagRepo, flagForgeType)
+		forge, owner, repoName, domain, err := resolve.Repo(flagRepo, flagForgeType)
 		if err != nil {
 			return err
 		}
@@ -33,8 +33,8 @@ var apiCmd = &cobra.Command{
 		endpoint = strings.ReplaceAll(endpoint, "{owner}", owner)
 		endpoint = strings.ReplaceAll(endpoint, "{repo}", repoName)
 
-		baseURL := apiBaseURL(domain, flagForgeType)
-		url := baseURL + "/" + strings.TrimLeft(endpoint, "/")
+		baseURL := apiBaseURL(forge, domain)
+		url := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(endpoint, "/")
 
 		var body io.Reader
 		if len(flagAPIFields) > 0 {
@@ -118,28 +118,16 @@ var apiCmd = &cobra.Command{
 	},
 }
 
-func apiBaseURL(domain, forgeType string) string {
-	if forgeType == "" {
-		if cfg, err := config.Load(); err == nil && cfg != nil {
-			forgeType = cfg.Domains[domain].Type
-		}
+func apiBaseURL(forge forges.Forge, domain string) string {
+	provider, ok := forge.(forges.APIBaseURLProvider)
+	if ok {
+		return provider.APIBaseURL()
 	}
 
-	if forgeType == "" {
-		forgeType = knownDomainForgeType(domain)
-	}
+	return legacyAPIBaseURL(domain)
+}
 
-	switch forgeType {
-	case "github":
-		return "https://api." + domain
-	case "gitlab":
-		return "https://" + domain + "/api/v4"
-	case "bitbucket":
-		return "https://api.bitbucket.org/2.0"
-	case "gitea", "forgejo":
-		return "https://" + domain + "/api/v1"
-	}
-
+func legacyAPIBaseURL(domain string) string {
 	switch {
 	case strings.Contains(domain, "github"):
 		return "https://api." + domain
@@ -149,21 +137,6 @@ func apiBaseURL(domain, forgeType string) string {
 		return "https://api.bitbucket.org/2.0"
 	default:
 		return "https://" + domain + "/api/v1"
-	}
-}
-
-func knownDomainForgeType(domain string) string {
-	switch domain {
-	case "github.com":
-		return "github"
-	case "gitlab.com":
-		return "gitlab"
-	case "codeberg.org":
-		return "forgejo"
-	case "bitbucket.org":
-		return "bitbucket"
-	default:
-		return ""
 	}
 }
 

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/git-pkgs/forge/internal/config"
 	"github.com/git-pkgs/forge/internal/resolve"
 	"github.com/spf13/cobra"
 )
@@ -118,7 +119,26 @@ var apiCmd = &cobra.Command{
 }
 
 func apiBaseURL(domain, forgeType string) string {
-	_ = forgeType
+	if forgeType == "" {
+		if cfg, err := config.Load(); err == nil && cfg != nil {
+			forgeType = cfg.Domains[domain].Type
+		}
+	}
+
+	if forgeType == "" {
+		forgeType = knownDomainForgeType(domain)
+	}
+
+	switch forgeType {
+	case "github":
+		return "https://api." + domain
+	case "gitlab":
+		return "https://" + domain + "/api/v4"
+	case "bitbucket":
+		return "https://api.bitbucket.org/2.0"
+	case "gitea", "forgejo":
+		return "https://" + domain + "/api/v1"
+	}
 
 	switch {
 	case strings.Contains(domain, "github"):
@@ -129,6 +149,21 @@ func apiBaseURL(domain, forgeType string) string {
 		return "https://api.bitbucket.org/2.0"
 	default:
 		return "https://" + domain + "/api/v1"
+	}
+}
+
+func knownDomainForgeType(domain string) string {
+	switch domain {
+	case "github.com":
+		return "github"
+	case "gitlab.com":
+		return "gitlab"
+	case "codeberg.org":
+		return "forgejo"
+	case "bitbucket.org":
+		return "bitbucket"
+	default:
+		return ""
 	}
 }
 

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/git-pkgs/forge/internal/config"
+)
+
+func TestAPIBaseURLKnownDomains(t *testing.T) {
+	tests := []struct {
+		name      string
+		domain    string
+		forgeType string
+		want      string
+	}{
+		{
+			name:   "github",
+			domain: "github.com",
+			want:   "https://api.github.com",
+		},
+		{
+			name:   "gitlab",
+			domain: "gitlab.com",
+			want:   "https://gitlab.com/api/v4",
+		},
+		{
+			name:   "codeberg",
+			domain: "codeberg.org",
+			want:   "https://codeberg.org/api/v1",
+		},
+		{
+			name:   "bitbucket",
+			domain: "bitbucket.org",
+			want:   "https://api.bitbucket.org/2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := apiBaseURL(tt.domain, tt.forgeType)
+			if got != tt.want {
+				t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", tt.domain, tt.forgeType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIBaseURLUnknownDomainWithForgeType(t *testing.T) {
+	tests := []struct {
+		name      string
+		forgeType string
+		want      string
+	}{
+		{
+			name:      "github",
+			forgeType: "github",
+			want:      "https://api.mylab.example.org",
+		},
+		{
+			name:      "gitlab",
+			forgeType: "gitlab",
+			want:      "https://mylab.example.org/api/v4",
+		},
+		{
+			name:      "gitea",
+			forgeType: "gitea",
+			want:      "https://mylab.example.org/api/v1",
+		},
+		{
+			name:      "forgejo",
+			forgeType: "forgejo",
+			want:      "https://mylab.example.org/api/v1",
+		},
+		{
+			name:      "bitbucket",
+			forgeType: "bitbucket",
+			want:      "https://api.bitbucket.org/2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := apiBaseURL("mylab.example.org", tt.forgeType)
+			if got != tt.want {
+				t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", "mylab.example.org", tt.forgeType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIBaseURLUnknownDomainWithConfigType(t *testing.T) {
+	config.ResetCache()
+	defer config.ResetCache()
+
+	xdgConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	configDir := filepath.Join(xdgConfigHome, "forge")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "config")
+	if err := os.WriteFile(configPath, []byte(`[mylab.example.org]
+type = gitlab
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := apiBaseURL("mylab.example.org", "")
+	want := "https://mylab.example.org/api/v4"
+	if got != want {
+		t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", "mylab.example.org", "", got, want)
+	}
+}
+
+func TestAPIBaseURLUnknownDomainWithoutForgeTypeOrConfig(t *testing.T) {
+	config.ResetCache()
+	defer config.ResetCache()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	got := apiBaseURL("mylab.example.org", "")
+	want := "https://mylab.example.org/api/v1"
+	if got != want {
+		t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", "mylab.example.org", "", got, want)
+	}
+}

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -5,92 +5,110 @@ import (
 	"path/filepath"
 	"testing"
 
+	forges "github.com/git-pkgs/forge"
+	"github.com/git-pkgs/forge/bitbucket"
+	"github.com/git-pkgs/forge/gitea"
+	ghforge "github.com/git-pkgs/forge/github"
+	glforge "github.com/git-pkgs/forge/gitlab"
 	"github.com/git-pkgs/forge/internal/config"
+	"github.com/git-pkgs/forge/internal/resolve"
 )
 
-func TestAPIBaseURLKnownDomains(t *testing.T) {
+func TestAPIBaseURLFromForge(t *testing.T) {
 	tests := []struct {
-		name      string
-		domain    string
-		forgeType string
-		want      string
+		name string
+		f    forges.Forge
+		want string
+	}{
+		{
+			name: "github",
+			f:    ghforge.New("", nil),
+			want: "https://api.github.com",
+		},
+		{
+			name: "github enterprise",
+			f:    ghforge.NewWithBase("https://github.enterprise.example.org", "", nil),
+			want: "https://github.enterprise.example.org/api/v3",
+		},
+		{
+			name: "gitlab",
+			f:    glforge.New("https://mylab.example.org", "", nil),
+			want: "https://mylab.example.org/api/v4",
+		},
+		{
+			name: "gitea",
+			f:    gitea.New("https://gitea.example.org", "", nil),
+			want: "https://gitea.example.org/api/v1",
+		},
+		{
+			name: "forgejo",
+			f:    gitea.New("https://forgejo.example.org", "", nil),
+			want: "https://forgejo.example.org/api/v1",
+		},
+		{
+			name: "bitbucket",
+			f:    bitbucket.New("", nil),
+			want: "https://api.bitbucket.org/2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := apiBaseURL(tt.f, "fallback.example.org")
+			if got != tt.want {
+				t.Fatalf("APIBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIBaseURLFallsBackToLegacyDomainHeuristics(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		want   string
 	}{
 		{
 			name:   "github",
-			domain: "github.com",
-			want:   "https://api.github.com",
+			domain: "github.example.org",
+			want:   "https://api.github.example.org",
 		},
 		{
 			name:   "gitlab",
-			domain: "gitlab.com",
-			want:   "https://gitlab.com/api/v4",
-		},
-		{
-			name:   "codeberg",
-			domain: "codeberg.org",
-			want:   "https://codeberg.org/api/v1",
+			domain: "gitlab.example.org",
+			want:   "https://gitlab.example.org/api/v4",
 		},
 		{
 			name:   "bitbucket",
-			domain: "bitbucket.org",
+			domain: "bitbucket.example.org",
 			want:   "https://api.bitbucket.org/2.0",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := apiBaseURL(tt.domain, tt.forgeType)
-			if got != tt.want {
-				t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", tt.domain, tt.forgeType, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestAPIBaseURLUnknownDomainWithForgeType(t *testing.T) {
-	tests := []struct {
-		name      string
-		forgeType string
-		want      string
-	}{
 		{
-			name:      "github",
-			forgeType: "github",
-			want:      "https://api.mylab.example.org",
-		},
-		{
-			name:      "gitlab",
-			forgeType: "gitlab",
-			want:      "https://mylab.example.org/api/v4",
-		},
-		{
-			name:      "gitea",
-			forgeType: "gitea",
-			want:      "https://mylab.example.org/api/v1",
-		},
-		{
-			name:      "forgejo",
-			forgeType: "forgejo",
-			want:      "https://mylab.example.org/api/v1",
-		},
-		{
-			name:      "bitbucket",
-			forgeType: "bitbucket",
-			want:      "https://api.bitbucket.org/2.0",
+			name:   "default",
+			domain: "forge.example.org",
+			want:   "https://forge.example.org/api/v1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := apiBaseURL("mylab.example.org", tt.forgeType)
+			got := apiBaseURL(&mockForge{}, tt.domain)
 			if got != tt.want {
-				t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", "mylab.example.org", tt.forgeType, got, tt.want)
+				t.Fatalf("apiBaseURL(..., %q) = %q, want %q", tt.domain, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestAPIBaseURLUnknownDomainWithConfigType(t *testing.T) {
+func TestAPIBaseURLUsesLegacyFallbackForUnknownDomainWithoutConfiguredForgeType(t *testing.T) {
+	got := apiBaseURL(&mockForge{}, "mylab.example.org")
+	want := "https://mylab.example.org/api/v1"
+	if got != want {
+		t.Fatalf("apiBaseURL(..., %q) = %q, want %q", "mylab.example.org", got, want)
+	}
+}
+
+func TestAPIBaseURLUsesConfiguredForgeTypeForUnknownDomain(t *testing.T) {
 	config.ResetCache()
 	defer config.ResetCache()
 
@@ -108,22 +126,14 @@ type = gitlab
 		t.Fatal(err)
 	}
 
-	got := apiBaseURL("mylab.example.org", "")
+	forge, _, _, domain, err := resolve.Repo("mylab.example.org/imt/deployments", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := apiBaseURL(forge, domain)
 	want := "https://mylab.example.org/api/v4"
 	if got != want {
-		t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", "mylab.example.org", "", got, want)
-	}
-}
-
-func TestAPIBaseURLUnknownDomainWithoutForgeTypeOrConfig(t *testing.T) {
-	config.ResetCache()
-	defer config.ResetCache()
-
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-	got := apiBaseURL("mylab.example.org", "")
-	want := "https://mylab.example.org/api/v1"
-	if got != want {
-		t.Fatalf("apiBaseURL(%q, %q) = %q, want %q", "mylab.example.org", "", got, want)
+		t.Fatalf("apiBaseURL(..., %q) = %q, want %q", domain, got, want)
 	}
 }


### PR DESCRIPTION
Fix `forge api` API base URL selection for self-hosted forge instances.

`forge api` previously selected the API root using domain-name substring checks, for example by looking for `gitlab` in the hostname. This breaks self-hosted instances whose domain does not include the expected forge-specific substring.

Closes https://github.com/git-pkgs/forge/issues/140

## Changes

- Extract API base URL selection into `apiBaseURL`.
- Resolve the API root from:
  1. explicit `--forge-type`
  2. configured domain `type`
  3. known-domain defaults
  4. existing hostname heuristics as fallback
- Add unit tests for:
  - known domains
  - unknown domains with explicit forge type
  - unknown domains with configured forge type
  - unknown domains without type information
