### PR TITLE
Use Go 1.26.6 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/git-pkgs/forge
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	code.gitea.io/sdk/gitea v0.25.1
 	github.com/git-pkgs/purl v0.1.16


### PR DESCRIPTION
Keep the existing minimum Go version while selecting Go 1.26.6 as the preferred toolchain for development and CI.